### PR TITLE
fix(ci): automatically apdate `dev` branch when push is made in `main` branch

### DIFF
--- a/.github/workflows/update_dev_branch.yml
+++ b/.github/workflows/update_dev_branch.yml
@@ -1,0 +1,20 @@
+name: Sync Main to Dev
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  sync-dev:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Merge Main into Dev
+        run: |
+          git checkout dev
+          git pull origin main --no-edit --no-ff -m "up-to-date dev branch"
+          git push origin dev


### PR DESCRIPTION
Push in `main` branch trigger a workflow that update `dev` branch automatically. So, the development branch is always up-to-date with `main`.