### PR TITLE
ci/update releases

### DIFF
--- a/.github/workflows/manual_release.yml
+++ b/.github/workflows/manual_release.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    permissions:
+    permissions: 
       contents: write
 
     steps:

--- a/.github/workflows/manual_release.yml
+++ b/.github/workflows/manual_release.yml
@@ -6,6 +6,11 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -28,12 +33,6 @@ jobs:
       - name: Get Tag Release
         run: echo "TAG=v$(python setup.py --version)" >> $GITHUB_ENV
 
-      - name: Generate changelog
-        id: changelog
-        uses: metcalfc/changelog-generator@v0.4.4
-        with:
-          mytoken: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Create Release
         id: create_release
         uses: actions/create-release@v1
@@ -42,6 +41,5 @@ jobs:
         with:
           tag_name: ${{ env.TAG }}
           release_name: Release ${{ env.TAG }}
-          body: ${{ steps.changelog.outputs.changelog }}
           draft: true
           prerelease: false

--- a/.github/workflows/manual_release.yml
+++ b/.github/workflows/manual_release.yml
@@ -7,9 +7,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      pull-requests: write
-      issues: write
+      contents: write
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
- delete changelog generator
- set release as draft. When action is completed it require our last click to publish the release. I decide do this to customize release notes. 