### PR TITLE
Update PRBS Function and Remove generate_prbs Utility

### DIFF
--- a/opticomlib/devices.py
+++ b/opticomlib/devices.py
@@ -73,6 +73,13 @@ def PRBS(order: Literal[7, 9, 11, 15, 20, 23, 31],
     out : :obj:`binary_sequence`
         generated pseudorandom binary sequence
 
+    Raises
+    ------
+    ValueError
+        If ``order`` is not in [7, 9, 11, 15, 20, 23, 31].
+    TypeError
+        If ``len`` is not an integer.
+
     Examples
     --------
     For more details, see [prbs]_.
@@ -98,7 +105,13 @@ def PRBS(order: Literal[7, 9, 11, 15, 20, 23, 31],
     """
     tic()
     taps = {7: [7,6], 9: [9,5], 11: [11,9], 15: [15,14], 20: [20,3], 23: [23,18], 31: [31,28]}
-    len = len if len is not None else 2**order-1
+    
+    if len is not None:
+        if not isinstance(len, int):
+            raise TypeError('The parameter `len` must be an integer.')
+        len = min(len, 2**order-1)
+    else:
+        len = 2**order-1
     
     if order not in taps.keys():
         raise ValueError('The parameter `order` must be one of the following values (7, 9, 11, 15, 20, 23, 31).')

--- a/opticomlib/devices.py
+++ b/opticomlib/devices.py
@@ -2,20 +2,20 @@
 .. rubric:: Devices
 .. autosummary::
 
-   PRBS                  -- Pseudorandom binary sequence generator
-   DAC                   -- Digital-to-analog converter (DAC) model
-   PM                    -- Optical phase modulator (PM) model
-   MZM                   -- Mach-Zehnder modulator (MZM) model
-   BPF                   -- Optical band-pass filter (BPF) bessel model
-   EDFA                  -- Erbium-doped fiber amplifier (EDFA) simple model
-   DM                    -- Dispersion medium model
-   FIBER                 -- Optical fiber model (dispersion, attenuation and non-linearities, Split-Step Fourier Method)
-   LPF                   -- Electrical low-pass filter (LPF) bessel model
-   PD                    -- Photodetector (PD) model
-   ADC                   -- Analog-to-digital converter (ADC) model
-   GET_EYE               -- Eye diagram parameters and metrics estimator
-   SAMPLER               -- Sampler device
-   FBG                   -- Fiber Bragg Grating (FBG) model
+   PRBS                  
+   DAC                   
+   PM                    
+   MZM                   
+   BPF                   
+   EDFA                  
+   DM                    
+   FIBER                 
+   LPF                   
+   PD                    
+   ADC                   
+   GET_EYE               
+   SAMPLER               
+   FBG                   
 """
 
 
@@ -24,7 +24,6 @@ import numpy as np
 import scipy.signal as sg
 from scipy.integrate import solve_ivp
 from typing import Literal, Union, Callable
-from numpy import ndarray
 from scipy.constants import pi, k as kB, e, h, c
 from numpy.fft import fft, ifft, fftshift, ifftshift
 
@@ -32,8 +31,7 @@ import matplotlib.pyplot as plt
 plt.rcParams['font.family'] = 'serif' 
 
 import sklearn.cluster as sk
-from tqdm.auto import tqdm # barra de progreso
-from numpy.lib.scimath import sqrt as csqrt
+from tqdm.auto import tqdm # progress bar
 
 import warnings
 
@@ -47,7 +45,6 @@ from .typing import (
 )
 
 from .utils import (
-    generate_prbs,
     idbm,
     idb,
     db,
@@ -60,66 +57,72 @@ from .utils import (
     dispersion,
 )
 
-
-
-def PRBS(n=2**8, 
-         user=[], 
-         order=None):
+def PRBS(order: Literal[7, 9, 11, 15, 20, 23, 31], 
+         len: int = None):
     r"""**Pseudorandom binary sequence generator**
 
     Parameters
     ----------
-    n : int, optional, default: 2**8
-        lenght of random binary sequence
-    user : str or array_like, optional, default: []
-        binary sequence user pattern
-    order : int, optional, default: None
+    order : :obj:`int`, {7, 9, 11, 15, 20, 23, 31}
         degree of the generating pseudorandom polynomial
+    len : :obj:`int`, optional
+        lenght of output binary sequence
 
     Returns
     -------
-    seq : binary_sequence
-        generated binary sequence
+    out : :obj:`binary_sequence`
+        generated pseudorandom binary sequence
 
     Examples
     --------
-    Using parameter **n**, this function generate a random sequence of lenght `n`. Internally it use ``numpy.random.randint`` function.
-    
+    For more details, see [prbs]_.
+
     >>> from opticomlib.devices import PRBS
-    >>> PRBS(10).data
-    array([0, 0, 1, 0, 1, 1, 0, 0, 0, 1], dtype=uint8)  #random
+    >>> PRBS(7, len=10).print("PRBS")
 
-    On the other hand, the **user** parameter can be used for a custom sequence.
-    We can input it in *str* format separating the values by spaces ``' '`` or by commas ``','``. 
+    :: 
+  
+        -----------------------------
+        ***    binary_sequence    ***
+        -----------------------------
+            data  :  [1 0 0 0 0 0 0 1 0 0]
+            len   :  10
+            size  :  440 bytes
+            time  :  0 s
 
-    >>> PRBS(user='1 0 1 0   0 1 1 1   0,1,0,0   1,1,0,1').data
-    array([1, 0, 1, 0, 0, 1, 1, 1, 0, 1, 0, 0, 1, 1, 0, 1], dtype=uint8)
+        <opticomlib.typing.binary_sequence object at 0x000002385FD7D7F0>
 
-    The last way in which the function can be used is by passing the **order** of the generating polynomial
-    as an argument, which will return a pseudo-random binary sequence of lenght :math:`2^{order}-1`, using an internal algorithm.
-
-    >>> PRBS(order=7).data 
-    array([1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 1, 0, 1,
-        0, 0, 0, 1, 1, 1, 1, 0, 0, 1, 0, 0, 0, 1, 0, 1, 1, 0, 0, 1, 1, 1,
-        0, 1, 0, 1, 0, 0, 1, 1, 1, 1, 1, 0, 1, 0, 0, 0, 0, 1, 1, 1, 0, 0,
-        0, 1, 0, 0, 1, 0, 0, 1, 1, 0, 1, 1, 0, 1, 0, 1, 1, 0, 1, 1, 1, 1,
-        0, 1, 1, 0, 0, 0, 1, 1, 0, 1, 0, 0, 1, 0, 1, 1, 1, 0, 1, 1, 1, 0,
-        0, 1, 1, 0, 0, 1, 0, 1, 0, 1, 0, 1, 1, 1, 1, 1, 1], dtype=uint8)
+    References
+    ----------
+    .. [prbs] "Pseudorandom binary sequence" https://en.wikipedia.org/wiki/Pseudorandom_binary_sequence
     """
     tic()
+    taps = {7: [7,6], 9: [9,5], 11: [11,9], 15: [15,14], 20: [20,3], 23: [23,18], 31: [31,28]}
+    len = len if len is not None else 2**order-1
+    
+    if order not in taps.keys():
+        raise ValueError('The parameter `order` must be one of the following values (7, 9, 11, 15, 20, 23, 31).')
 
-    if user:
-        output = binary_sequence( user )
-    elif order:
-        output = binary_sequence( generate_prbs(order) )
-    else:
-        output = binary_sequence( np.random.randint(0, 2, n) )
+    prbs = np.empty((len,), dtype=np.uint8)  # Preallocate memory
+    lfsr = (1<<order)-1 # initial state of the LFSR
+    tap1, tap2 = np.array(taps[order])-1
+
+    index = 0
+    while index < len:
+        prbs[index] = lfsr&1
+        new = ((lfsr>>tap1)^(lfsr>>tap2))&1
+        lfsr = ((lfsr<<1) | new) & (1<<order)-1 
+        index += 1
+        if lfsr == (1<<order)-1:
+            break
+    
+    output = binary_sequence( prbs )
     output.execution_time = toc()
+    
     return output
 
 
-
-def DAC(input: Union[str, list, tuple, ndarray, binary_sequence], 
+def DAC(input: Union[str, list, tuple, np.ndarray, binary_sequence], 
         Vout: float=None,
         pulse_shape: Literal['rect','gaussian']='rect', 
         **kargs):  
@@ -215,7 +218,7 @@ def DAC(input: Union[str, list, tuple, ndarray, binary_sequence],
 
 
 def PM(op_input: optical_signal, 
-       el_input: Union[float, ndarray, electrical_signal], 
+       el_input: Union[float, np.ndarray, electrical_signal], 
        Vpi: float=5.0):
     r"""
     **Optical Phase Modulator**
@@ -315,7 +318,7 @@ def PM(op_input: optical_signal,
         el_input = el_input.signal
         if el_input.size != op_input.signal.len():
             raise ValueError("The length of `el_input` must be equal to the length of `op_input`.")
-    elif isinstance(el_input, ndarray):
+    elif isinstance(el_input, np.ndarray):
         if len(el_input) != op_input.len():
             raise ValueError("The length of `el_input` must be equal to the length of `op_input`.")
     else:
@@ -334,7 +337,7 @@ def PM(op_input: optical_signal,
 
 
 def MZM(op_input: optical_signal, 
-        el_input: Union[float, ndarray, electrical_signal], 
+        el_input: Union[float, np.ndarray, electrical_signal], 
         bias: float=0.0, 
         Vpi: float=5.0, 
         loss_dB: float=0.0, 
@@ -463,7 +466,7 @@ def MZM(op_input: optical_signal,
         el_input = el_input.signal
         if el_input.size != op_input.signal.len():
             raise ValueError("La longitud de `el_input` debe ser igual a la longitud de `op_input`.")
-    elif isinstance(el_input, ndarray):
+    elif isinstance(el_input, np.ndarray):
         if len(el_input) != op_input.len():
             raise ValueError("La longitud de `el_input` debe ser igual a la longitud de `op_input`.")
     else:
@@ -795,8 +798,7 @@ def FIBER(input: optical_signal,
     return output
 
 
-
-def LPF(input: Union[ndarray, electrical_signal], 
+def LPF(input: Union[np.ndarray, electrical_signal], 
         BW: float, 
         n: int=4, 
         fs: float=None,
@@ -860,7 +862,7 @@ def LPF(input: Union[ndarray, electrical_signal],
     """
     tic()
 
-    if not isinstance(input, (ndarray, electrical_signal)):
+    if not isinstance(input, (np.ndarray, electrical_signal)):
         raise TypeError("`input` must be of type (ndarray or electrical_signal).")
     elif isinstance(input, electrical_signal):
             signal = input.signal
@@ -1048,7 +1050,7 @@ def ADC(input: electrical_signal, fs: float=None, BW: float=None, nbits: int=8) 
     return output
 
 
-def GET_EYE(input: Union[electrical_signal, optical_signal, ndarray], nslots: int=4096, sps_resamp: int=None):
+def GET_EYE(input: Union[electrical_signal, optical_signal, np.ndarray], nslots: int=4096, sps_resamp: int=None):
     r"""
     **Get Eye Parameters Estimator**
 
@@ -1144,7 +1146,7 @@ def GET_EYE(input: Union[electrical_signal, optical_signal, ndarray], nslots: in
 
     eye_dict = {}
 
-    if isinstance(input, ndarray):
+    if isinstance(input, np.ndarray):
         if input.ndim == 2:
             if input.shape[0] != 2 and input.shape[1] == 2:
                 input = input.T

--- a/opticomlib/utils.py
+++ b/opticomlib/utils.py
@@ -1,27 +1,26 @@
 """
 .. rubric:: Functions
 .. autosummary::
-
-    generate_prbs          -- Generate a pseudo-random binary sequence (PRBS) of desired order.
-    dec2bin                -- Convert a decimal number to its binary representation.
-    str2array              -- Convert a string to a numeric array.
-    get_time               -- Get the average time of execution of a line of code.
-    tic                    -- Start a timer.
-    toc                    -- Stop a timer.
-    db                     -- Convert a number value to dB.
-    dbm                    -- Convert a power value in W to dBm.
-    idb                    -- Convert a dB value to a number.
-    idbm                   -- Convert a dBm value to a power value in W.
-    gaus                   -- Gaussian function.
-    Q                      -- Q(x) = 1/2*erfc(x/sqrt(2)) function.
-    phase                  -- Calculate the unwrapped phase of a frequency response.
-    tau_g                  -- Calculate the group delay of a frequency response.
-    dispersion             -- Calculate the dispersion of a frequency response.
-    bode                   -- Plot the Bode plot of a given transfer function H (magnitud, phase, group delay and dispersion).
-    rcos                   -- Raised cosine function.
-    si                     -- Unit of measure classifier.
-    norm                   -- Normalize a vector to 1.
-    nearest                -- Find the nearest value in an array.
+     
+    dec2bin                
+    str2array              
+    get_time              
+    tic                    
+    toc                    
+    db                     
+    dbm                    
+    idb                    
+    idbm                   
+    gaus                   
+    Q                      
+    phase                  
+    tau_g                  
+    dispersion             
+    bode                   
+    rcos                   
+    si                     
+    norm                   
+    nearest                
 """
 
 import re
@@ -30,7 +29,6 @@ import timeit, time as tm
 import scipy.special as sp
 import scipy.signal as sg
 
-from numpy import ndarray
 from typing import Literal, Union
 
 from scipy.constants import pi, c
@@ -42,58 +40,6 @@ import warnings
 
 Array_Like = (list, tuple, np.ndarray)
 Number = (int, float)
-
-
-
-def generate_prbs(order: int=None):
-    r"""
-    Generates a pseudo-random binary sequence (PRBS) of desired order.
-
-    Parameters
-    ----------
-    order : int, default: 7
-        Order of the generator polynomial. Valid options are {7, 9, 11, 15, 20, 23, 31}.
-
-    Returns
-    -------
-    np.ndarray
-        PRBS sequence of length ``2^order-1``.
-
-    Raises
-    ------
-    ValueError
-        If ``order`` is not in {7, 9, 11, 15, 20, 23, 31}.
-
-    Example
-    -------
-    .. code-block:: python
-
-        >>> generate_prbs(7)
-        array([1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 1, 0, 1,
-               0, 0, 0, 1, 1, 1, 1, 0, 0, 1, 0, 0, 0, 1, 0, 1, 1, 0, 0, 1, 1, 1,
-               0, 1, 0, 1, 0, 0, 1, 1, 1, 1, 1, 0, 1, 0, 0, 0, 0, 1, 1, 1, 0, 0,
-               0, 1, 0, 0, 1, 0, 0, 1, 1, 0, 1, 1, 0, 1, 0, 1, 1, 0, 1, 1, 1, 1,
-               0, 1, 1, 0, 0, 0, 1, 1, 0, 1, 0, 0, 1, 0, 1, 1, 1, 0, 1, 1, 1, 0,
-               0, 1, 1, 0, 0, 1, 0, 1, 0, 1, 0, 1, 1, 1, 1, 1, 1], dtype=uint8) 
-    """
-    
-    taps = {7: [7,6], 9: [9,5], 11: [11,9], 15: [15,14], 20: [20,3], 23: [23,18], 31: [31,28]}
-    if order is None: 
-        order = 7
-    elif order not in taps.keys():
-        raise ValueError(f'`order` must be in {list(taps.keys())}')
-
-    prbs = []
-    lfsr = (1<<order)-1
-    tap1, tap2 = np.array(taps[order])-1
-
-    while True:
-        prbs.append(lfsr&1)
-        new = ((lfsr>>tap1)^(lfsr>>tap2))&1
-        lfsr = ((lfsr<<1) | new) & (1<<order)-1
-        if lfsr == (1<<order)-1:
-            break
-    return np.array(prbs, np.uint8)
 
 
 
@@ -509,7 +455,7 @@ def Q(x):
     return 0.5*sp.erfc(x/2**0.5) 
 
 
-def phase(H: ndarray):
+def phase(H: np.ndarray):
     r"""
     Calculate the unwrapped phase of a frequency response.
 
@@ -547,7 +493,7 @@ def phase(H: ndarray):
     """
     return np.unwrap(np.angle(H))
 
-def tau_g(H: ndarray, fs: float):
+def tau_g(H: np.ndarray, fs: float):
     r"""
     Calculate the group delay of a frequency response.
 
@@ -588,7 +534,7 @@ def tau_g(H: ndarray, fs: float):
     dw = 2*pi*fs/H.size
     return np.diff(phase(H))/dw * 1e12
 
-def dispersion(H: ndarray, fs: float, f0: float):
+def dispersion(H: np.ndarray, fs: float, f0: float):
     """
     Calculate the dispersion of a frequency response.
 
@@ -613,7 +559,7 @@ def dispersion(H: ndarray, fs: float, f0: float):
 
 
 
-def bode(H: ndarray, 
+def bode(H: np.ndarray, 
          fs: float, 
          f0: float=None, 
          xaxis: Literal['f','w','lambda']='f', 
@@ -663,7 +609,7 @@ def bode(H: ndarray,
         >>> from opticomlib import bode
         >>> H, phase, tau_g = bode(H, fs, ret=True, show_=False)
     """
-    if not isinstance(H, ndarray):
+    if not isinstance(H, np.ndarray):
         raise ValueError('`H` must be a numpy.ndarray.')
     
     f = fftshift(fftfreq(H.size, d=1/fs))

--- a/tests/devices_test.py
+++ b/tests/devices_test.py
@@ -1,0 +1,18 @@
+import unittest
+import numpy as np
+
+from opticomlib.devices import (
+    PRBS,
+)
+class TestDevices(unittest.TestCase):
+    def test_PRBS(self):
+        with self.assertRaises(TypeError):
+            PRBS(order=15, len='20') # len must be an integer
+        with self.assertRaises(ValueError):
+            PRBS(order=8) # order must be one of [7, 9, 11, 15, 20, 23, 31]
+
+        prbs = PRBS(order=15, len=20)
+        self.assertEqual(len(prbs), 20) 
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This Pull Request (PR) introduces several changes to the PRBS (Pseudo-Random Binary Sequence) function within the project. Here's a summary of the updates:

1. **del: delete generate_prbs function from utils.py module**
   - Remove the `generate_prbs` function from the `utils.py` module.

2. **breaking: PRBS function no longer accepts n and user arguments.**
   - Remove the `user` argument from the PRBS function, suggesting it can be passed directly to `DAC()` or `binary_sequence`.
   - Rename the `n` parameter to `len` and limit the output length of the LFSR.
   - Use `np.ndarray` instead of `ndarray`.

3. **feat: Add error handling for len parameter in PRBS function**
   - Introduce error handling for the `len` parameter in the PRBS function.
   - Raise a new exception if `len` is not an integer.
   - Fix `len` to `2**order-1` if it exceeds this value.
   - Add exception raises to docstring.

4. **tests: Add test for PRBS function in module devices_test.py**
   - Add test cases for the PRBS function in the `devices_test.py` module.