### PR TITLE
New methods for `binary_sequence` class

### DIFF
--- a/opticomlib/typing.py
+++ b/opticomlib/typing.py
@@ -287,6 +287,7 @@ class binary_sequence():
 
         __init__
         __str__
+        __repr__
         print
         __len__
         __getitem__
@@ -344,6 +345,9 @@ class binary_sequence():
             msg += '\t' +\
                 f'time  :  {si(self.execution_time, "s", 1)}\n'
         return msg
+    
+    def __repr__(self):
+        return f'binary_sequence({str(self.data)})'
     
     def print(self, msg: str=None): 
         """Print object parameters.

--- a/opticomlib/typing.py
+++ b/opticomlib/typing.py
@@ -363,10 +363,23 @@ class binary_sequence():
         """Get number of slots of the binary sequence."""
         return self.len()
 
-    def __getitem__(self, key):
-        """Get a slice of the binary sequence."""
-        return binary_sequence(self.data[key])
-    
+    def __getitem__(self, slice: Union[int, slice]):
+        """Get a slice of the binary sequence. 
+        
+        Parameters
+        ----------
+        slice : :obj:`int` or :obj:`slice`
+            The slice to get. 
+
+        Returns
+        -------
+        :obj:`int` or :obj:`binary_sequence`
+            The value of the slot if `slice` is an integer, or a new binary sequence object with the result of the slice.
+        """
+        if isinstance(slice, int):
+            return self.data[slice]
+        return binary_sequence(self.data[slice])
+
     def __add__(self, other): 
         """ Concatenate two binary sequences, adding to the end.
 

--- a/opticomlib/typing.py
+++ b/opticomlib/typing.py
@@ -407,7 +407,7 @@ class binary_sequence():
             other = np.array(other, dtype=bool)
         if other.size != self.data.size and other.size != 1:
             raise ValueError(f"Can't compare binary sequences with shapes {self.data.shape} and {other.shape}")
-        return self.data == other
+        return binary_sequence(self.data == other)
 
     def __add__(self, other): 
         """ Concatenate two binary sequences, adding to the end.

--- a/opticomlib/typing.py
+++ b/opticomlib/typing.py
@@ -347,7 +347,7 @@ class binary_sequence():
         return msg
     
     def __repr__(self):
-        return f'binary_sequence({str(self.data)})'
+        return f'binary_sequence({str(self.data.astype(np.uint8))})'
     
     def print(self, msg: str=None): 
         """Print object parameters.

--- a/opticomlib/typing.py
+++ b/opticomlib/typing.py
@@ -293,6 +293,7 @@ class binary_sequence():
         __eq__
         __add__
         __radd__
+        __invert__
         len
         ones
         zeros
@@ -477,6 +478,18 @@ class binary_sequence():
             raise TypeError("Can't concatenate binary_sequence with type {}".format(type(other)))
         out = np.concatenate((other, self.data))
         return binary_sequence(out)
+
+    def __invert__(self):
+        """Invert the binary sequence 
+        
+        Implement a bitwise not `~` operation on the binary sequence. Example: `~binary_sequence([1,0,1,0])` returns `binary_sequence([0,1,0,1])`.
+
+        Returns
+        -------
+        binary_sequence
+            A new binary sequence object with the result of the inversion.
+        """
+        return binary_sequence(~self.data)
 
     def len(self): 
         """Get number of slots of the binary sequence.

--- a/opticomlib/typing.py
+++ b/opticomlib/typing.py
@@ -290,6 +290,7 @@ class binary_sequence():
         print
         __len__
         __getitem__
+        __eq__
         __add__
         __radd__
         len
@@ -379,6 +380,29 @@ class binary_sequence():
         if isinstance(slice, int):
             return self.data[slice]
         return binary_sequence(self.data[slice])
+    
+    def __eq__(self, other):
+        """Compare two binary sequences.
+
+        Parameters
+        ----------
+        other : :obj:`str` or :obj:`binary_sequence` or :obj:`Array_Like`
+            The binary sequence to compare.
+            
+        Returns
+        -------
+        :obj:`np.ndarray` of :obj:`bool`
+            A boolean array with the result of the comparison. ``True`` if the elements are equal, ``False`` otherwise.
+        """
+        if isinstance(other, binary_sequence):
+            other = other.data
+        if isinstance(other, str):
+            other = str2array(other, bool)  
+        else:
+            other = np.array(other, dtype=bool)
+        if other.size != self.data.size and other.size != 1:
+            raise ValueError(f"Can't compare binary sequences with shapes {self.data.shape} and {other.shape}")
+        return self.data == other
 
     def __add__(self, other): 
         """ Concatenate two binary sequences, adding to the end.


### PR DESCRIPTION
✨ Features:
- Add `binary_sequence` representation like `binary_sequence([...])` 
- Overload of `__eq__` operator to allow 'equal' comparison operations between binary sequences. For example:
  ```
  >>> binary_sequence('010') == '010'
  binary_sequence([1 1 1])
  >>> [1,0,1] == binary_sequence('010')
  binary_sequence([0 0 0])
  >>> binary_sequence('010') == 1
  binary_sequence([0 1 0])
  ```
- Overload of `__invert__` operator to make a `not` element-wise operation over binary sequence. For example: 
  ```
  >>> ~binary_sequence('101')
  binary_sequence([0 1 0])
  ```
🐛 Bugs:
- A bug in `__getitem__` was fixed when integer slice were passed. Now it return a boolean value. For example:
  ```
  >>> binary_sequence('0101')[3]
  True
  ```