### PR TITLE
Typing module Unit-Tests, some new features and refactor typing code

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -6,12 +6,12 @@
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
-import opticomlib
+import opticomlib as op
 
 project = 'opticomlib'
 copyright = '2024, Ing. Armando P. Romeu'
 author = 'Ing. Armando P. Romeu'
-release = opticomlib.__version__
+version = op.__version__
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/opticomlib/__init__.py
+++ b/opticomlib/__init__.py
@@ -1,5 +1,5 @@
 from .typing import *
 from .utils import *
 
-__version__ = '0.4.15'
+__version__ = '1.0.0'
 

--- a/opticomlib/devices.py
+++ b/opticomlib/devices.py
@@ -650,7 +650,7 @@ def DM(input: optical_signal, D: float, retH: bool=False):
         gv(N=7, sps=32, R=10e9)
 
         signal = DAC('0,0,0,1,0,0,0', pulse_shape='gaussian')
-        input = optical_signal( signal.signal/signal.power()**0.5*idbm(20)**0.5 )
+        input = optical_signal( signal.signal/signal.power()**0.5*idbm(20)**0.5, n_pol=2 )
 
         output, H = DM(input, D=4000, retH=True)
 
@@ -755,7 +755,7 @@ def FIBER(input: optical_signal,
         gv(sps=32, R=10e9)
 
         signal = DAC('0,0,0,1,0,0,0', pulse_shape='gaussian')
-        input = optical_signal( signal.signal/signal.power()**0.5*idbm(20) )
+        input = optical_signal( signal.signal/signal.power()**0.5*idbm(20)**0.5, n_pol=2)
 
         output = FIBER(input, length=50, alpha=0.01, beta_2=-20, gamma=0.1, show_progress=True)
 

--- a/opticomlib/devices.py
+++ b/opticomlib/devices.py
@@ -1225,20 +1225,29 @@ def GET_EYE(input: Union[electrical_signal, optical_signal, np.ndarray], nslots:
 
     t_set = np.array(list(set(t)))
 
-    # The following vector will be used only to determine the crossing times
-    tt = t[(input>v25)&(input<v75)]
+    try: 
+        # The following vector will be used only to determine the crossing times
+        tt = t[(input>v25)&(input<v75)]
 
-    # We get the centroid of the time data
-    tm = np.mean(sk.KMeans(n_clusters=2, n_init=10).fit(tt.reshape(-1,1)).cluster_centers_)
+        # We get the centroid of the time data
+        tm = np.mean(sk.KMeans(n_clusters=2, n_init=10).fit(tt.reshape(-1,1)).cluster_centers_)
 
-    # We obtain the left crossing time
-    t_left = find_nearest(t_set, np.mean(tt[tt<tm])); eye_dict['t_left'] = t_left
+        # We obtain the left crossing time
+        t_left = find_nearest(t_set, np.mean(tt[tt<tm])); eye_dict['t_left'] = t_left
 
-    # We obtain the crossing time from the right
-    t_right = find_nearest(t_set, np.mean(tt[tt>tm])); eye_dict['t_right'] = t_right
+        # We obtain the crossing time from the right
+        t_right = find_nearest(t_set, np.mean(tt[tt>tm])); eye_dict['t_right'] = t_right
 
-    # Determine the center of the eye
-    t_center = find_nearest(t_set, (t_left + t_right)/2); eye_dict['t_opt'] = t_center
+        # Determine the center of the eye
+        t_center = find_nearest(t_set, (t_left + t_right)/2); eye_dict['t_opt'] = t_center
+    
+    except ValueError:
+        t_left = -0.5; eye_dict['t_left'] = t_left
+        t_right = 0.5; eye_dict['t_right'] = t_right
+        t_center = 0.0; eye_dict['t_opt'] = t_center
+    
+    except Exception as e:
+        raise e
 
     # For 20% of the center of the eye diagram
     t_dist = t_right - t_left; eye_dict['t_dist'] = t_dist
@@ -1275,7 +1284,7 @@ def GET_EYE(input: Union[electrical_signal, optical_signal, np.ndarray], nslots:
     eye_h = mu1 - 3 * s1 - mu0 - 3 * s0; eye_dict['eye_h'] = eye_h
 
     eye_dict['execution_time'] = toc()
-    return eye(eye_dict)
+    return eye(**eye_dict)
 
 
 def SAMPLER(input: electrical_signal, _eye_: eye):

--- a/opticomlib/lab.py
+++ b/opticomlib/lab.py
@@ -622,7 +622,7 @@ class PPG3204():
 
 
     def set_bits_shift(self, bsh: Union[int, list[int]], CHs: Union[int, list[int]] = None):
-        """Set the bits shift of the pattern
+        r"""Set the bits shift of the pattern
         
         Parameters
         ----------
@@ -700,7 +700,7 @@ class PPG3204():
 
 
     def set_freq(self, freq: float):
-        """Set the bit rate of the pattern
+        r"""Set the bit rate of the pattern
 
         - *Range*: 1.5 GHz to 32 GHz
         - *Resolution*: 10 kb/s

--- a/opticomlib/typing.py
+++ b/opticomlib/typing.py
@@ -370,7 +370,7 @@ class binary_sequence():
         return self.len()
 
     def __getitem__(self, slice: Union[int, slice]):
-        """Get a slice of the binary sequence. 
+        """Get a slice of the binary sequence (``x[slice]``). 
         
         Parameters
         ----------
@@ -387,7 +387,7 @@ class binary_sequence():
         return binary_sequence(self.data[slice])
     
     def __eq__(self, other):
-        """Compare two binary sequences.
+        """Compare two binary sequences using ``==`` operator.
 
         Parameters
         ----------
@@ -410,7 +410,7 @@ class binary_sequence():
         return binary_sequence(self.data == other)
 
     def __add__(self, other): 
-        """ Concatenate two binary sequences, adding to the end.
+        """ Concatenate two binary sequences, adding to the end (``+``).
 
         Parameters
         ----------
@@ -431,7 +431,7 @@ class binary_sequence():
         
         See Also
         --------
-        __radd__ : Concatenates two binary sequence, adding at the beginning.
+        __radd__ : Concatenates two binary sequence, adding at the beginning (``+``).
         """
         if isinstance(other, str):
             other = str2array(other, bool)
@@ -447,7 +447,7 @@ class binary_sequence():
         return binary_sequence(out)
     
     def __radd__(self, other): 
-        """ Concatenate two binary sequences, adding to the beginning.
+        """ Concatenate two binary sequences, adding to the beginning (``+``).
 
         Parameters
         ----------
@@ -484,9 +484,9 @@ class binary_sequence():
         return binary_sequence(out)
 
     def __invert__(self):
-        """Invert the binary sequence 
+        """Invert the binary sequence using the ``~`` operator. 
         
-        Implement a bitwise not `~` operation on the binary sequence. Example: `~binary_sequence([1,0,1,0])` returns `binary_sequence([0,1,0,1])`.
+        Implement a bitwise not ``~`` operation on the binary sequence. Example: ``~binary_sequence([1,0,1,0])`` returns ``binary_sequence([0,1,0,1])``.
 
         Returns
         -------

--- a/opticomlib/typing.py
+++ b/opticomlib/typing.py
@@ -1109,6 +1109,7 @@ class electrical_signal():
              ylabel: str=None, 
              style: Literal['dark', 'light'] = 'dark',
              grid: bool=False,
+             hold: bool=True,
              **kwargs: dict): 
         r"""Plot real part of electrical signal.
 
@@ -1126,6 +1127,8 @@ class electrical_signal():
             Style of plot. Defaults to 'dark'.
         grid : :obj:`bool`, optional
             If show grid. Defaults to False.
+        hold : :obj:`bool`, optional
+            If hold the current plot. Defaults to True.
         \*\*kwargs : :obj:`dict`
             Aditional keyword arguments compatible with matplotlib.pyplot.plot().
 
@@ -1146,6 +1149,9 @@ class electrical_signal():
         else:
             raise ValueError('`style` must be "dark" or "light".')
         
+        if not hold:
+            plt.figure()
+
         plt.plot(t, (self[:n].signal+self[:n].noise).real, fmt, **kwargs)
         plt.xlabel(xlabel if xlabel else 'Time [ns]')
         plt.ylabel(ylabel if ylabel else 'Amplitude [V]')
@@ -1169,6 +1175,7 @@ class electrical_signal():
             yscale: Literal['linear','dbm']='dbm', 
             style: Literal['dark', 'light'] = 'dark',
             grid: bool=True,
+            hold: bool=True,
             **kwargs: dict):
         """Plot Power Spectral Density (PSD) of the electrical signal.
 
@@ -1188,6 +1195,8 @@ class electrical_signal():
             Style of plot. Defaults to 'dark'.
         grid : :obj:`bool`, optional
             If show grid. Defaults to True.
+        hold : :obj:`bool`, optional
+            If hold the current plot. Defaults to True.
         **kwargs : :obj:`dict`
             Aditional matplotlib arguments.
 
@@ -1221,6 +1230,9 @@ class electrical_signal():
         else:
             raise TypeError('`yscale` must be one of the following values ("linear", "dbm")')
         
+        if not hold:
+            plt.figure()
+
         plt.plot( *args, **kwargs )
         plt.ylabel( ylabel )
         plt.xlabel( xlabel if xlabel else 'Frequency [GHz]')
@@ -1571,6 +1583,7 @@ class optical_signal(electrical_signal):
              ylabel: str=None,
              style: Literal['dark', 'light'] = 'dark',
              grid: bool=False,
+             hold: bool=True,
              **kwargs): 
         r"""
         Plot intensity of optical signal for selected polarization mode.
@@ -1601,6 +1614,8 @@ class optical_signal(electrical_signal):
         
         grid : :obj:`bool`, optional
             If show grid. Default is ``False``.
+        hold : :obj:`bool`, optional
+            If hold the current figure. Default is ``True``.
         \*\*kwargs: :obj:`dict`
             Aditional matplotlib arguments.
 
@@ -1658,6 +1673,9 @@ class optical_signal(electrical_signal):
         
         label = kwargs.pop('label', None) if mode == 'both' else None
 
+        if not hold:
+            plt.figure()
+
         plt.plot( *args, **kwargs)
         plt.xlabel(xlabel if xlabel else 'Time [ns]')
         plt.ylabel(ylabel if ylabel else 'Power [mW]')
@@ -1684,6 +1702,7 @@ class optical_signal(electrical_signal):
             yscale: Literal['linear', 'dbm']='dbm', 
             style: Literal['dark', 'light'] = 'dark',
             grid: bool=True,
+            hold: bool=True,
             **kwargs: dict):
         r"""Plot Power Spectral Density (PSD) of the electrical signal.
 
@@ -1718,6 +1737,8 @@ class optical_signal(electrical_signal):
 
         grid : bool, optional
             If show grid. Default is ``True``.
+        hold : bool, optional
+            If hold the current figure. Default is ``True``.
         \*\*kwargs : :obj:`dict`
             Aditional matplotlib arguments.
 
@@ -1779,6 +1800,9 @@ class optical_signal(electrical_signal):
                 raise TypeError('argument `mode` should be ("x", "y" or "both")')    
         
         label = kwargs.pop('label', None)
+
+        if not hold:
+            plt.figure()
 
         plt.plot( *args, **kwargs)
         plt.ylabel(ylabel)
@@ -1848,21 +1872,27 @@ class eye():
         Eye height.
     """
 
-    def __init__(self, eye_dict={}):
-        """ Initialize the eye diagram object.
+    def __init__(self, **kwargs: dict):
+        r""" Initialize the eye diagram object.
 
         Parameters
         ----------
-        eye_dict : :obj:`dict`, optional
+        \*\*kwargs : :obj:`dict`, optional
             Dictionary with the eye diagram parameters.
         """
 
-        if eye_dict:
-            for key, value in eye_dict.items():
+        if kwargs:
+            for key, value in kwargs.items():
                 setattr(self, key, value)
+            self.empty = False
+        else:
+            self.empty = True
         
     def __str__(self, title: str=None): 
         """Return a formatted string with the eye diagram data."""
+        if self.empty:
+            raise ValueError('Empty eye diagram object.')
+
         if title is None:
             title = self.__class__.__name__
         
@@ -1894,12 +1924,12 @@ class eye():
         return self
     
     def plot(self, 
-             medias_=True, 
-             legend_=True, 
+             medias_: bool=True, 
+             legend_: bool=True, 
              style: Literal['dark', 'light']='dark', 
-             cmap:Literal['viridis', 'plasma', 'inferno', 'cividis', 'magma', 'winter']='winter',
+             cmap: Literal['viridis', 'plasma', 'inferno', 'cividis', 'magma', 'winter']='winter',
              label: str = '',
-             savefig=None):
+             savefig: str=None):
         """ Plot eye diagram.
 
         Parameters
@@ -1915,13 +1945,16 @@ class eye():
         label : :obj:`str`, optional
             Label to show in title.
         savefig : :obj:`str`, optional
-            If not None, save figure with the given name.
+            Name of the file to save the plot. If None, the plot is not saved.
+            Input just the name of the file without extension (extension is .png by default).
 
         Returns
         -------
         self: :obj:`eye`
             Same object
         """
+        if self.empty:
+            raise ValueError('Empty eye diagram object.')
 
         ## SETTINGS
 
@@ -2038,7 +2071,7 @@ class eye():
         t_slider.on_changed(update_t_line)
 
         if savefig: 
-            plt.savefig(savefig, dpi=300)
+            plt.savefig('.'.join((savefig, 'png')), dpi=300)
         return self
 
     def show(self):

--- a/opticomlib/typing.py
+++ b/opticomlib/typing.py
@@ -1792,7 +1792,7 @@ class optical_signal(electrical_signal):
                 if isinstance(fmt, (list, tuple)):
                     args = (f, psd[0], fmt[0], f, psd[1], fmt[1])
                 elif isinstance(fmt, str):
-                    args = (f, psd[0], fmt, f, psd[f], fmt)
+                    args = (f, psd[0], fmt, f, psd[1], fmt)
                 else:
                     warnings.warn('`fmt` must be a string or a list of strings for both polarizations signals, using default value.')
                     args = (f, psd[0], '-', f, psd[1], '-')

--- a/opticomlib/typing.py
+++ b/opticomlib/typing.py
@@ -307,7 +307,7 @@ class binary_sequence():
 
         Parameters
         ----------
-        data : :obj:`str`, 1D array_like
+        data : :obj:`str`, 1D array_like or scalar
             The binary sequence data.
         """
         if isinstance(data, str):
@@ -317,9 +317,11 @@ class binary_sequence():
 
         if not np.all((data == 0) | (data == 1)): 
             raise ValueError("The array must contain only 0's and 1's!")
-        if data.ndim != 1:
+        if data.ndim > 1:
             raise ValueError(f"Binary sequence must be 1D array, invalid shape {data.shape}")
-
+        if data.ndim == 0 and data.size == 1:
+            data = data[np.newaxis]
+        
         self.data = data.astype(bool)
         """The binary sequence data, a 1D numpy array of boolean values."""
         self.execution_time = None
@@ -347,6 +349,7 @@ class binary_sequence():
         return msg
     
     def __repr__(self):
+        np.set_printoptions(threshold=20)
         return f'binary_sequence({str(self.data.astype(np.uint8))})'
     
     def print(self, msg: str=None): 
@@ -381,9 +384,7 @@ class binary_sequence():
         -------
         :obj:`int` or :obj:`binary_sequence`
             The value of the slot if `slice` is an integer, or a new binary sequence object with the result of the slice.
-        """
-        if isinstance(slice, int):
-            return self.data[slice]
+        """ 
         return binary_sequence(self.data[slice])
     
     def __eq__(self, other):

--- a/opticomlib/typing.py
+++ b/opticomlib/typing.py
@@ -610,6 +610,13 @@ class electrical_signal():
             raise TypeError("`signal` must be of type list, tuple or numpy array!")
         else:
             signal = np.array(signal, dtype=complex) # shape (1xN)
+
+        if self.__class__ == electrical_signal:
+            if signal.ndim != 1:
+                raise ValueError("Signal must be 1D when electrical_signal is instantiated")
+        else:
+            if signal.ndim != 2:
+                raise ValueError("Signal must be 2D when optical_signal is instantiated")
         
         if noise is None:
             noise = np.zeros_like(signal, dtype=complex)
@@ -1269,21 +1276,34 @@ class optical_signal(electrical_signal):
             The noise values, default is `None`.
         """
         if signal is not None:
-            ndim = np.array(signal).ndim
+            signal = np.array(signal, dtype=complex)
+            ndim = signal.ndim
             if ndim > 2 or ndim < 1:
                 raise ValueError("`signal` must be a 1D or 2D array!")
             if ndim == 1:
                 signal = np.array([signal, np.zeros_like(signal)])
+            elif ndim == 2 and signal.shape[0] == 1:
+                signal = np.array([signal[0], np.zeros_like(signal[0])])
+
         elif noise is not None:
             ndim = np.array(noise).ndim
             if ndim > 2 or ndim < 1:
                 raise ValueError("`noise` must be a 1D or 2D array!")
             if ndim == 1:
                 noise = np.array([noise, np.zeros_like(noise)])
+            elif ndim == 2 and noise.shape[0] == 2:
+                noise = np.array([noise[0], np.zeros_like(noise[0])])
         else:
             raise KeyError("`signal` or `noise` must be provided!")
         
         super().__init__( signal, noise )  
+    
+    def __repr__(self):
+        signal = str(self.signal).replace('\n', '\n\t' + 13*' ')
+        noise = str(self.noise).replace('\n', '\n\t' + 13*' ')
+        np.set_printoptions(precision=1, threshold=20)
+        return f'optical_signal(signal={signal},\n\t\tnoise={noise})'
+
     
     def len(self): 
         """Get number of samples of the optical signal.

--- a/setup.py
+++ b/setup.py
@@ -68,6 +68,6 @@ setup(
     install_requires=REQUIREMENTS,
     long_description=LONG_DESCRIPTION[LONG_DESCRIPTION.find("#"):],
     long_description_content_type="text/markdown",
-    python_requires='>3.8',
+    python_requires='>=3.10',
     include_package_data=True,
 )

--- a/tests/ppm_test.py
+++ b/tests/ppm_test.py
@@ -90,7 +90,7 @@ class TestPPM(unittest.TestCase):
         mu1 = [0.9, 1.0, 1.1, 1.2]
         s0 = s1 = [0.1, 0.2, 0.3, 0.4]
 
-        inputs = [eye({'mu0':mu0[i], 'mu1':mu1[i], 's0':s0[i], 's1':s1[i]}) for i in range(4)]
+        inputs = [eye(**{'mu0':mu0[i], 'mu1':mu1[i], 's0':s0[i], 's1':s1[i]}) for i in range(4)]
 
         M = 4
         out = [0.514014014014014, 0.6532532532532533, 0.8085085085085084, 0.9693693693693693]
@@ -103,7 +103,7 @@ class TestPPM(unittest.TestCase):
 
     def test_ber_analizer(self):
         bits = np.random.randint(0, 2, 2**11) # binary sequence of 2^11 bits
-        eye_obj = eye({'mu0':0.0, 'mu1':1.0, 's0':0.1, 's1':0.1})
+        eye_obj = eye(**{'mu0':0.0, 'mu1':1.0, 's0':0.1, 's1':0.1})
         M = 4
 
         # First, test raises conditions work properly

--- a/tests/typing_test.py
+++ b/tests/typing_test.py
@@ -17,6 +17,9 @@ from opticomlib.typing import (
     eye,
 )
 
+
+
+
 class TestGlobalVariables(unittest.TestCase):
     def test_global_variables(self):
         gv = global_variables()
@@ -54,6 +57,9 @@ class TestGlobalVariables(unittest.TestCase):
             gv.print()
         except Exception as e:
             self.fail(f"gv.print() raised {type(e).__name__} unexpectedly!")
+
+
+
 
 class TestBinarySequence(unittest.TestCase):
     inputs = ['000011110000',
@@ -113,6 +119,9 @@ class TestBinarySequence(unittest.TestCase):
                 assert_(bits.ones() == 4)
                 assert_(bits.zeros() == 8)
 
+
+
+
 class TestElectricalSignal(unittest.TestCase):
     inputs = [np.arange(100).tolist(), np.arange(100)] 
 
@@ -121,7 +130,7 @@ class TestElectricalSignal(unittest.TestCase):
         assert_raises(ValueError, lambda: electrical_signal([0,1,2], [0,1,2,3]))
         assert_raises(ValueError, lambda: electrical_signal([0,1,2,3], [0,1,2]))
         assert_raises(TypeError, lambda: electrical_signal(signal='0,0.1,0.2,0.3'))
-        assert_raises(TypeError, lambda: electrical_signal(noise='0,0.1,0.2,0.3'))
+        assert_raises(ValueError, lambda: electrical_signal([[1,2,3]]))
 
         for input in self.inputs:
             with self.subTest(input_type=type(input)):
@@ -230,6 +239,16 @@ class TestElectricalSignal(unittest.TestCase):
                 signal = electrical_signal(input, noise=np.ones(100))
                 assert_equal(signal.apply(np.abs).signal, np.abs(input))
                 assert_equal(signal.apply(np.abs).noise, np.abs(signal.noise))
+
+
+
+
+class TestOpticalSignal(unittest.TestCase):
+    pass
+
+
+
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/typing_test.py
+++ b/tests/typing_test.py
@@ -15,6 +15,7 @@ from opticomlib.typing import (
     electrical_signal,
     optical_signal,
     eye,
+    gv
 )
 
 
@@ -81,13 +82,12 @@ class TestBinarySequence(unittest.TestCase):
                 assert_(bits.execution_time is None) # Check that the execution time is None
 
     def test_print(self):
-        for input in self.inputs:
-            with self.subTest(input_type=type(input)):
-                bits = binary_sequence(input)
-                try:
-                    bits.print()
-                except Exception as e:
-                    self.fail(f"bits.print() raised {type(e).__name__} unexpectedly!")
+        input = '000011110000'
+        bits = binary_sequence(input)
+        try:
+            bits.print('binary test')
+        except Exception as e:
+            self.fail(f"bits.print() raised {type(e).__name__} unexpectedly!")
     
     def test_getitem(self):
         for input in self.inputs:
@@ -134,6 +134,7 @@ class TestElectricalSignal(unittest.TestCase):
 
     def test_init(self):
         assert_raises(TypeError, lambda: electrical_signal())
+        assert_raises(TypeError, lambda: electrical_signal(noise=[1,2,3]))
         assert_raises(ValueError, lambda: electrical_signal([0,1,2], [0,1,2,3]))
         assert_raises(ValueError, lambda: electrical_signal([0,1,2,3], [0,1,2]))
         assert_raises(ValueError, lambda: electrical_signal([[1,2,3]]))
@@ -152,7 +153,7 @@ class TestElectricalSignal(unittest.TestCase):
         y = np.sin(2*pi*5*x)
         signal = electrical_signal(x, y)
         try:
-            signal.print("something")
+            signal.print("electric test")
         except Exception as e:
             self.fail(f"signal.print() raised {type(e).__name__} unexpectedly!")
 
@@ -172,9 +173,13 @@ class TestElectricalSignal(unittest.TestCase):
                 signal = electrical_signal(input)
                 
                 assert_equal((signal + signal).signal, np.arange(100)*2)
+
+                assert_equal((signal + input).signal, np.arange(100)*2)
+                # assert_equal((input + signal).signal, np.arange(100)*2)  ## revisar esta linea
+
                 assert_equal((signal + 1).signal, np.arange(100)+1)
                 assert_equal((1 + signal).signal, np.arange(100)+1)
-                assert_raises(ValueError, lambda: signal + [0,3,0]) # Different length
+                assert_raises(ValueError, lambda: signal + input[:4]) # Different length
                 
     def test_sub_and_rsub(self):
         for input in self.inputs:
@@ -182,9 +187,13 @@ class TestElectricalSignal(unittest.TestCase):
                 signal = electrical_signal(input)
                 
                 assert_equal((signal - signal).signal, np.zeros(100))
+                
+                assert_equal((signal - input).signal, np.zeros(100))
+                # assert_equal((input - signal).signal, np.zeros(100))  ## revisar esta linea
+
                 assert_equal((signal - 1).signal, np.arange(100)-1)
                 assert_equal((1 - signal).signal, 1-np.arange(100))
-                assert_raises(ValueError, lambda: signal - [0,3,0]) # Different length
+                assert_raises(ValueError, lambda: signal - input[:4]) # Different length
 
     def test_mul_and_rmul(self):
         for input in self.inputs:
@@ -192,9 +201,13 @@ class TestElectricalSignal(unittest.TestCase):
                 signal = electrical_signal(input)
                 
                 assert_equal((signal * signal).signal, np.arange(100)**2)
+                
+                assert_equal((signal * input).signal, np.arange(100)**2)
+                # assert_equal((input * signal).signal, np.arange(100)**2)  ## revisar esta linea
+                
                 assert_equal((signal * 2).signal, np.arange(100)*2)
                 assert_equal((2 * signal).signal, np.arange(100)*2)
-                assert_raises(ValueError, lambda: signal * [0,3,0]) # Different length
+                assert_raises(ValueError, lambda: signal * input[:4]) # Different length
     
     def test_gt_and_lt(self):
         for input in self.inputs:
@@ -203,6 +216,10 @@ class TestElectricalSignal(unittest.TestCase):
                 
                 assert_equal((signal + 1 > 0),  np.ones(100))
                 assert_equal((signal < 100), np.ones(100))
+
+                assert_equal((signal > input),  np.zeros(100))
+                assert_equal((signal < input),  np.zeros(100))
+                assert_raises(ValueError, lambda: signal > input[:4])
 
     def test_call(self):
         for input in self.inputs:
@@ -234,26 +251,327 @@ class TestElectricalSignal(unittest.TestCase):
                 assert_raises(ValueError, lambda: signal.abs('z'))
 
     def test_phase(self):
-        for input in self.inputs:
-            with self.subTest(input_type=type(input)):
-                signal = electrical_signal(input, noise=np.ones(100))
-                assert_equal(signal.phase(), np.unwrap(np.angle(np.arange(100) + signal.noise)))
+        signal = electrical_signal(self.inputs[-1] + self.inputs[-1]*1j)
+        assert_equal(signal.phase(), np.concatenate(([0], np.ones(99)*pi/4)))
     
     def test_apply(self):
         for input in self.inputs:
             with self.subTest(input_type=type(input)):
                 signal = electrical_signal(input, noise=np.ones(100))
                 assert_equal(signal.apply(np.abs).signal, np.arange(100))
-                assert_equal(signal.apply(np.abs).noise, np.abs(signal.noise))
+                assert_equal(signal.apply(np.abs).noise, np.ones(100))
 
 
 
 
 class TestOpticalSignal(unittest.TestCase):
-    pass
+    signals_1p = ['+0,1,2,3,4+0j,5.', 
+                  [0,1,2,3,4,5], 
+                  np.arange(6)]
+    noises_1p = ['+0,-1,-2,-3,-4+0i,-5.',
+                [0,-1,-2,-3,-4,-5],
+                -np.arange(6)]
+    
+    signals_2p = ['+0,1,2,3,4+0j,5.; +0,1,2,3,4+0i,5.',
+                  [[0,1,2,3,4,5]],
+                  np.array([[0,1,2,3,4,5]])]
+
+    noises_2p = ['+0,-1,-2,-3,-4+0j,-5.; +0,-1,-2,-3,-4+0i,-5.',
+                 [[0,-1,-2,-3,-4,-5]],
+                 -np.array([[0,1,2,3,4,5]])]
+    
+    def test_init(self):
+        assert_raises(TypeError, lambda: optical_signal()) # No input
+        assert_raises(TypeError, lambda: optical_signal(noise=[[1,2,3]])) # no signal input
+        assert_raises(ValueError, lambda: optical_signal([0,1,2], [0,1,2,3])) # Different length
+        assert_raises(ValueError, lambda: optical_signal([0,1,2,3], [0,1,2])) # Different length
+        assert_raises(ValueError, lambda: optical_signal([[1,2,3], [5,6,7], [8,9,10]]))
+        assert_raises(ValueError, lambda: optical_signal([[[1,2,3]]]))
+
+        for sig, noi in zip(self.signals_1p, self.noises_1p):
+            with self.subTest(pol=1, type=type(sig)):
+                x = optical_signal(sig, noi)
+                
+                assert_equal(x.signal, np.arange(6))
+                assert_equal(x.noise, -np.arange(6))
+                assert_equal(x.n_pol, 1)
+                assert_equal(x.execution_time, None)
+                assert_equal(x.len(), 6)
+
+        for sig, noi in zip(self.signals_2p, self.noises_2p):
+            with self.subTest(pol=2, type=type(sig)):
+                x = optical_signal(sig, noi, n_pol=2)
+
+                assert_equal(x.signal, np.tile(np.arange(6),(2,1)))
+                assert_equal(x.noise, -np.tile(np.arange(6),(2,1)))
+                assert_equal(x.n_pol, 2)
+                assert_equal(x.execution_time, None)
+                assert_equal(x.len(), 6)
+
+    def test_print(self):
+        x_1p = optical_signal([1,2,3], [1,1,0])
+        x_2p = optical_signal([[1,2,3]], [[1,1,0]])
+        try:
+            x_1p.print("optic test 1 pol")
+            x_2p.print("optic test 2 pol")
+        except Exception as e:
+            self.fail(f"signal.print() raised {type(e).__name__} unexpectedly!")
+
+    def test_getitem(self):
+        for sig, noi in zip(self.signals_1p, self.noises_1p):
+            with self.subTest(pol=1, type=type(sig)):
+                x = optical_signal(sig, noi)
+                
+                assert_(x[0].signal == 0)
+                assert_equal(x[:].signal, np.arange(6))
+                assert_equal(x[1:-1].signal, np.arange(1,5))
+                
+                assert_(x[0].noise == 0)
+                assert_equal(x[:].noise, -np.arange(6))
+                assert_equal(x[1:-1].noise, -np.arange(1,5))
+                
+                assert_raises(IndexError, lambda: x[10])
+
+        for sig, noi in zip(self.signals_2p, self.noises_2p):
+            with self.subTest(pol=2, type=type(sig)):
+                x = optical_signal(sig, noi)
+                
+                assert_equal(x[0].signal, [[0],[0]])
+                assert_equal(x[:].signal, np.tile(np.arange(6),(2,1)))
+                assert_equal(x[1:-1].signal, np.array([[1,2,3,4], [1,2,3,4]]))
+                
+                assert_equal(x[0].noise, [[0],[0]])
+                assert_equal(x[:].noise, -np.tile(np.arange(6),(2,1)))
+                assert_equal(x[1:-1].noise, -np.array([[1,2,3,4], [1,2,3,4]]))
+                
+                assert_raises(IndexError, lambda: x[10])
+
+    def test_add_and_radd(self):
+        for sig, noi in zip(self.signals_1p, self.noises_1p):
+            with self.subTest(pol=1, type=type(sig)):
+                x = optical_signal(sig, noi, n_pol=1)
+                
+                # self + self = 2*self
+                assert_equal((x + x).signal, np.arange(6)*2) 
+                assert_equal((x + x).noise, -np.arange(6)*2) 
+
+                assert_equal((x + sig).signal, np.arange(6)*2) # suma por la derecha
+                assert_equal((x + sig).noise, np.zeros(6))
+
+                # assert_equal((sig + x).signal, np.arange(6)*2) # suma por la izquierda
+                # assert_equal((sig + x).noise, np.zeros(6))
+
+                assert_equal((x + 1).signal, np.arange(1,7)) # suma por la derecha
+                assert_equal((x + 1).noise, -np.arange(-1,5))
+
+                assert_equal((1 + x).signal, np.arange(1,7)) 
+                assert_equal((1 + x).noise, -np.arange(-1,5)) 
+                
+                assert_raises(ValueError, lambda: x + sig[:4]) # Different length
+
+        for sig, noi in zip(self.signals_2p, self.noises_2p):
+            with self.subTest(pol=2, type=type(sig)):
+                x = optical_signal(sig, noi, n_pol=2)
+                
+                # self + self = 2*self
+                assert_equal((x + x).signal, np.tile(np.arange(6),(2,1))*2) 
+                assert_equal((x + x).noise, -np.tile(np.arange(6),(2,1))*2) 
+
+                assert_equal((x + sig).signal, np.tile(np.arange(6),(2,1))*2)
+                assert_equal((x + sig).noise, np.zeros((2,6)))
+
+                # assert_equal((sig + x).signal, np.tile(np.arange(6),(2,1))*2)
+                # assert_equal((sig + x).noise, np.zeros((2,6)))
+
+                assert_equal((x + 1).signal, np.tile(np.arange(6),(2,1))+1)
+                assert_equal((x + 1).noise, -np.tile(np.arange(6),(2,1))+1)
+
+                assert_equal((1 + x).signal, np.tile(np.arange(6),(2,1))+1)
+                assert_equal((1 + x).noise, -np.tile(np.arange(6),(2,1))+1)
+
+                if type(sig) == str: assert_raises(ValueError, lambda: x + '+0,-1,-2') # Different length
+                else: assert_raises(ValueError, lambda: x + sig[0][:3]) # Different length
 
 
+    def test_sub_and_rsub(self):
+        for sig, noi in zip(self.signals_1p, self.noises_1p):
+            with self.subTest(pol=1, type=type(sig)):
+                x = optical_signal(sig, noi, n_pol=1)
+                
+                # self - self = 0
+                assert_equal((x - x).signal, np.zeros(6)) 
+                assert_equal((x - x).noise, np.zeros(6)) 
 
+                assert_equal((x - sig).signal, np.zeros(6))
+                assert_equal((x - noi).noise, np.zeros(6))
+
+                # assert_equal((sig - x).signal, np.zeros(100))
+                # assert_equal((sig - x).noise, np.zeros(100))
+
+                assert_equal((x - 1).signal, np.arange(6)-1)
+                assert_equal((x - 1).noise, -np.arange(6)-1)
+
+                assert_equal((1 - x).signal, 1-np.arange(6))
+                assert_equal((1 - x).noise, 1+np.arange(6))
+
+                assert_raises(ValueError, lambda: x - sig[:4])
+
+        for sig, noi in zip(self.signals_2p, self.noises_2p):
+            with self.subTest(pol=2, type=type(sig)):
+                x = optical_signal(sig, noi, n_pol=2)
+                
+                # self - self = 0
+                assert_equal((x - x).signal, np.zeros((2,6))) 
+                assert_equal((x - x).noise, np.zeros((2,6))) 
+
+                assert_equal((x - sig).signal, np.zeros((2,6)))
+                assert_equal((x - noi).noise, np.zeros((2,6)))
+
+                # assert_equal((sig - x).signal, np.zeros(100))
+                # assert_equal((sig - x).noise, np.zeros(100))
+
+                assert_equal((x - 1).signal, np.tile(np.arange(6),(2,1))-1)
+                assert_equal((x - 1).noise, -np.tile(np.arange(6),(2,1))-1)
+
+                assert_equal((1 - x).signal, 1-np.tile(np.arange(6),(2,1)))
+                assert_equal((1 - x).noise, 1+np.tile(np.arange(6),(2,1)))
+
+                if type(sig) == str: assert_raises(ValueError, lambda: x - '+0,-1,-2') # Different length
+                else: assert_raises(ValueError, lambda: x - sig[0][:3]) # Different length
+
+    def test_mul_and_rmul(self):
+        for sig, noi in zip(self.signals_1p, self.noises_1p):
+            with self.subTest(pol=1, type=type(sig)):
+                x = optical_signal(sig, noi, n_pol=1)
+                
+                # self * self = self**2
+                assert_equal((x * x).signal, np.arange(6)**2) 
+                assert_equal((x * x).noise, np.arange(6)**2) 
+
+                assert_equal((x * sig).signal, np.arange(6)**2)
+                assert_equal((x * sig).noise, -np.arange(6)**2)
+
+                # assert_equal((sig * x).signal, np.arange(6)**2)
+                # assert_equal((sig * x).noise, np.zeros(6))
+
+                assert_equal((x * 2).signal, np.arange(6)*2)
+                assert_equal((x * 2).noise, -np.arange(6)*2)
+
+                assert_equal((2 * x).signal, np.arange(6)*2)
+                assert_equal((2 * x).noise, -np.arange(6)*2)
+
+                assert_raises(ValueError, lambda: x * sig[:4])
+
+        for sig, noi in zip(self.signals_2p, self.noises_2p):
+            with self.subTest(pol=2, type=type(sig)):
+                x = optical_signal(sig, noi, n_pol=2)
+                
+                # self * self = self**2
+                assert_equal((x * x).signal, np.tile(np.arange(6),(2,1))**2) 
+                assert_equal((x * x).noise, np.tile(np.arange(6),(2,1))**2) 
+
+                assert_equal((x * sig).signal, np.tile(np.arange(6),(2,1))**2)
+                assert_equal((x * sig).noise, -np.tile(np.arange(6),(2,1))**2)
+
+                # assert_equal((sig * x).signal, np.tile(np.arange(6),(2,1))**2)
+                # assert_equal((sig * x).noise, -np.tile(np.arange(6),(2,1))**2)
+
+                assert_equal((x * 2).signal, np.tile(np.arange(6),(2,1))*2)
+                assert_equal((x * 2).noise, -np.tile(np.arange(6),(2,1))*2)
+
+                assert_equal((2 * x).signal, np.tile(np.arange(6),(2,1))*2)
+                assert_equal((2 * x).noise, -np.tile(np.arange(6),(2,1))*2)
+
+                if type(sig) == str: assert_raises(ValueError, lambda: x * '+0,-1,-2') # Different length
+                else: assert_raises(ValueError, lambda: x * sig[0][:3]) # Different length
+
+    def test_call(self):
+        for sig, noi in zip(self.signals_1p, self.noises_1p):
+            with self.subTest(pol=1, type=type(sig)):
+                x = optical_signal(sig, noi, n_pol=1)
+                
+                assert_equal(x('t').signal, np.fft.ifft(np.arange(6)))
+                assert_equal(x('t').noise, np.fft.ifft(-np.arange(6)))
+
+                assert_equal(x('f').signal, np.fft.fft(np.arange(6)))
+                assert_equal(x('f').noise, np.fft.fft(-np.arange(6)))
+                
+                assert_equal(x('w').signal, np.fft.fft(np.arange(6)))
+                assert_equal(x('w').noise, np.fft.fft(-np.arange(6)))
+                
+                assert_raises(ValueError, lambda: x('z'))
+
+                assert_equal(x('t', shift=True).signal, np.fft.ifftshift(np.fft.ifft(np.arange(6))))
+
+        for sig, noi in zip(self.signals_2p, self.noises_2p):
+            with self.subTest(pol=2, type=type(sig)):
+                x = optical_signal(sig, noi, n_pol=2)
+                
+                assert_equal(x('t').signal, np.fft.ifft(np.tile(np.arange(6),(2,1))))
+                assert_equal(x('f').signal, np.fft.fft(np.tile(np.arange(6),(2,1))))
+                assert_equal(x('w').signal, np.fft.fft(np.tile(np.arange(6),(2,1))))
+                assert_raises(ValueError, lambda: x('z'))
+
+                assert_equal(x('t', shift=True).signal, np.fft.ifftshift(np.fft.ifft(np.tile(np.arange(6),(2,1)))))
+
+    def test_power(self):
+        for sig, noi in zip(self.signals_1p, self.noises_1p):
+            with self.subTest(pol=1, type=type(sig)):
+                x = optical_signal(sig, noi, n_pol=1)
+                
+                assert_equal(x.power(), 0)
+                assert_equal(x.power('signal'), np.mean(np.arange(6)**2))
+                assert_equal(x.power('noise'), np.mean(np.arange(6)**2))
+                assert_raises(ValueError, lambda: x.power('z'))
+
+        for sig, noi in zip(self.signals_2p, self.noises_2p):
+            with self.subTest(pol=2, type=type(sig)):
+                x = optical_signal(sig, noi, n_pol=2)
+                
+                assert_equal(x.power(), 0)
+                assert_equal(x.power('signal'), np.tile(np.mean(np.arange(6)**2), 2))
+                assert_equal(x.power('noise'), np.tile(np.mean(np.arange(6)**2), 2))
+                assert_raises(ValueError, lambda: x.power('z'))
+
+    def test_w(self):
+        x = optical_signal(np.arange(6), -np.arange(6), n_pol=1)
+        assert_equal(x.w(), 2*pi*np.fft.fftfreq(6)*gv.fs)
+        assert_equal(x.w(shift=True), 2*pi*np.fft.fftshift(np.fft.fftfreq(6))*gv.fs)
+
+        x = optical_signal(np.arange(6), -np.arange(6), n_pol=2)
+        assert_equal(x.w(), 2*pi*np.fft.fftfreq(6)*gv.fs)
+        assert_equal(x.w(shift=True), 2*pi*np.fft.fftshift(np.fft.fftfreq(6))*gv.fs)
+
+    def test_phase(self):
+        sig, noi = self.signals_1p[-1][1:], self.noises_1p[-1][1:]
+
+        x = optical_signal(sig+1j*sig, noi-1j*noi, n_pol=1)
+        assert_equal(x.phase(), np.ones(5)*pi/2)
+
+        sig, noi = self.signals_2p[-1][:,1:], self.noises_2p[-1][:,1:]
+
+        x = optical_signal(sig+1j*sig, noi-1j*noi, n_pol=2)
+        assert_equal(x.phase(), np.tile(np.ones(5)*pi/2,(2,1)))
+
+    def test_plot(self):
+        x = optical_signal(np.ones(100), np.random.normal(0,0.05,100), n_pol=1)
+        try:
+            assert_(x.plot('--r', n=98, mode='x', xlabel='Time', ylabel='Intensity', style='light', grid=True)==x)
+        except Exception as e:
+            self.fail(f"x.plot() raised {type(e).__name__} unexpectedly!")
+
+        x = optical_signal(np.ones(100), np.random.normal(0,0.05,100), n_pol=2)
+        try:
+            assert_(x.plot(['r','b'], n=98, mode='both', xlabel='Time', ylabel='Intensity', style='dark', grid=True)==x)
+        except Exception as e:
+            self.fail(f"x.plot() raised {type(e).__name__} unexpectedly!")
+
+    def test_psd(self):
+        x = optical_signal(np.ones(100), np.random.normal(0,0.05,100), n_pol=1)
+        try:
+            assert_(x.psd('--r', mode='both', n=98, xlabel='Time', ylabel='Intensity', style='light', grid=True)==x)
+        except Exception as e:
+            self.fail(f"x.psd() raised {type(e).__name__} unexpectedly!")
 
 
 if __name__ == '__main__':

--- a/tests/typing_test.py
+++ b/tests/typing_test.py
@@ -113,5 +113,123 @@ class TestBinarySequence(unittest.TestCase):
                 assert_(bits.ones() == 4)
                 assert_(bits.zeros() == 8)
 
+class TestElectricalSignal(unittest.TestCase):
+    inputs = [np.arange(100).tolist(), np.arange(100)] 
+
+    def test_init(self):
+        assert_raises(KeyError, lambda: electrical_signal())
+        assert_raises(ValueError, lambda: electrical_signal([0,1,2], [0,1,2,3]))
+        assert_raises(ValueError, lambda: electrical_signal([0,1,2,3], [0,1,2]))
+        assert_raises(TypeError, lambda: electrical_signal(signal='0,0.1,0.2,0.3'))
+        assert_raises(TypeError, lambda: electrical_signal(noise='0,0.1,0.2,0.3'))
+
+        for input in self.inputs:
+            with self.subTest(input_type=type(input)):
+                signal = electrical_signal(input)
+                
+                assert_equal(signal.signal, np.arange(100))
+                assert_equal(signal.noise, np.zeros(100))
+                assert_equal(signal.execution_time, None)
+                assert_equal(signal.len(), 100)
+
+    def test_print(self):
+        x = np.linspace(0, 1, 100)
+        y = np.sin(2*pi*5*x)
+        signal = electrical_signal(x, y)
+        try:
+            signal.print("something")
+        except Exception as e:
+            self.fail(f"signal.print() raised {type(e).__name__} unexpectedly!")
+
+    def test_getitem(self):
+        for input in self.inputs:
+            with self.subTest(input_type=type(input)):
+                signal = electrical_signal(input)
+                assert_equal(signal[0][0], 0)
+                assert_equal(signal[:].signal, np.arange(100))
+                assert_equal(signal[4:-1].signal, np.arange(4,99))
+                assert_equal(signal.noise, np.zeros(100))
+                assert_raises(IndexError, lambda: signal[100])
+
+    def test_add_and_radd(self):
+        for input in self.inputs:
+            with self.subTest(input_type=type(input)):
+                signal = electrical_signal(input)
+                
+                assert_equal((signal + signal).signal, np.arange(100)*2)
+                assert_equal((signal + 1).signal, np.arange(100)+1)
+                assert_equal((1 + signal).signal, np.arange(100)+1)
+                assert_raises(ValueError, lambda: signal + [0,3,0]) # Different length
+                
+    def test_sub_and_rsub(self):
+        for input in self.inputs:
+            with self.subTest(input_type=type(input)):
+                signal = electrical_signal(input)
+                
+                assert_equal((signal - signal).signal, np.zeros(100))
+                assert_equal((signal - 1).signal, np.arange(100)-1)
+                assert_equal((1 - signal).signal, 1-np.arange(100))
+                assert_raises(ValueError, lambda: signal - [0,3,0]) # Different length
+
+    def test_mul_and_rmul(self):
+        for input in self.inputs:
+            with self.subTest(input_type=type(input)):
+                signal = electrical_signal(input)
+                
+                assert_equal((signal * signal).signal, np.arange(100)**2)
+                assert_equal((signal * 2).signal, np.arange(100)*2)
+                assert_equal((2 * signal).signal, np.arange(100)*2)
+                assert_raises(ValueError, lambda: signal * [0,3,0]) # Different length
+    
+    def test_gt_and_lt(self):
+        for input in self.inputs:
+            with self.subTest(input_type=type(input)):
+                signal = electrical_signal(input)
+                
+                assert_equal((signal + 1 > 0),  np.ones(100))
+                assert_equal((signal < 100), np.ones(100))
+
+    def test_call(self):
+        for input in self.inputs:
+            with self.subTest(input_type=type(input)):
+                signal = electrical_signal(input)
+                assert_equal(signal('t').signal, np.fft.ifft(input))
+                assert_equal(signal('f').signal, np.fft.fft(input))
+                assert_equal(signal('w').signal, np.fft.fft(input))
+                assert_raises(ValueError, lambda: signal('z'))
+
+                assert_equal(signal('t', shift=True).signal, np.fft.ifftshift(np.fft.ifft(input)))
+    
+    def test_power(self):
+        for input in self.inputs:
+            with self.subTest(input_type=type(input)):
+                signal = electrical_signal(input, noise=np.ones(100))
+                assert_equal(signal.power(), np.sum(np.abs(input + signal.noise)**2)/len(input))
+                assert_equal(signal.power('signal'), np.sum(np.abs(input)**2)/len(input))
+                assert_equal(signal.power('noise'), 1)
+                assert_raises(ValueError, lambda: signal.power('z'))
+
+    def test_abs(self):
+        for input in self.inputs:
+            with self.subTest(input_type=type(input)):
+                signal = electrical_signal(input, noise=np.ones(100))
+                assert_equal(signal.abs(), np.abs(input + signal.noise))
+                assert_equal(signal.abs('signal'), np.abs(input))
+                assert_equal(signal.abs('noise'), np.ones(100))
+                assert_raises(ValueError, lambda: signal.abs('z'))
+
+    def test_phase(self):
+        for input in self.inputs:
+            with self.subTest(input_type=type(input)):
+                signal = electrical_signal(input, noise=np.ones(100))
+                assert_equal(signal.phase(), np.unwrap(np.angle(input + signal.noise)))
+    
+    def test_apply(self):
+        for input in self.inputs:
+            with self.subTest(input_type=type(input)):
+                signal = electrical_signal(input, noise=np.ones(100))
+                assert_equal(signal.apply(np.abs).signal, np.abs(input))
+                assert_equal(signal.apply(np.abs).noise, np.abs(signal.noise))
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/typing_test.py
+++ b/tests/typing_test.py
@@ -261,6 +261,20 @@ class TestElectricalSignal(unittest.TestCase):
                 signal = electrical_signal(input, noise=np.ones(100))
                 assert_equal(signal.apply(np.abs).signal, np.arange(100))
                 assert_equal(signal.apply(np.abs).noise, np.ones(100))
+    
+    def test_plot(self):
+        x = electrical_signal(np.ones(100), np.random.normal(0,0.05,100))
+        try:
+            assert_(x.plot('-r', n=98, xlabel='Time', ylabel='Intensity', style='light', grid=True, hold=False)==x)
+        except Exception as e:
+            self.fail(f"x.plot() raised {type(e).__name__} unexpectedly!")
+
+    def test_psd(self):
+        x = electrical_signal(np.ones(100), np.random.normal(0,0.05,100))
+        try:
+            assert_(x.psd('--b', n=98, xlabel='Freq', ylabel='Spectra', style='dark', grid=False, hold=False)==x)
+        except Exception as e:
+            self.fail(f"x.psd() raised {type(e).__name__} unexpectedly!")
 
 
 
@@ -570,7 +584,13 @@ class TestOpticalSignal(unittest.TestCase):
     def test_psd(self):
         x = optical_signal(np.ones(100), np.random.normal(0,0.05,100), n_pol=1)
         try:
-            assert_(x.psd('--r', mode='both', n=98, xlabel='Time', ylabel='Intensity', style='light', grid=True, hold=False)==x)
+            assert_(x.psd('--r', mode='x', n=98, xlabel='Freq', ylabel='Spectra', style='light', grid=True, hold=False)==x)
+        except Exception as e:
+            self.fail(f"x.psd() raised {type(e).__name__} unexpectedly!")
+
+        x = optical_signal(np.ones(100), np.random.normal(0,0.05,100), n_pol=2)
+        try:
+            assert_(x.psd('--b', mode='both', n=98, xlabel='Freq', ylabel='Spectra', style='dark', grid=False, hold=False)==x)
         except Exception as e:
             self.fail(f"x.psd() raised {type(e).__name__} unexpectedly!")
 

--- a/tests/typing_test.py
+++ b/tests/typing_test.py
@@ -1,0 +1,117 @@
+import unittest
+import numpy as np
+from scipy.constants import c, pi
+from numpy.testing import (
+    assert_,
+    assert_allclose,
+    assert_almost_equal,
+    assert_equal,
+    assert_raises,
+)
+
+from opticomlib.typing import (
+    global_variables,
+    binary_sequence,
+    electrical_signal,
+    optical_signal,
+    eye,
+)
+
+class TestGlobalVariables(unittest.TestCase):
+    def test_global_variables(self):
+        gv = global_variables()
+
+        ## Test default attributes
+        assert_(gv.sps == 16)
+        assert_(gv.R == 1e9)
+        assert_(gv.fs == 16e9)
+        assert_(gv.dt == 1/16e9)
+        assert_(gv.wavelength == 1550e-9)
+        assert_(gv.f0 == c/1550e-9)
+        assert_(gv.N is None)
+        assert_(gv.t is None)
+        assert_(gv.dw is None)
+        assert_(gv.w is None)
+        assert_raises(AttributeError, lambda: gv.alpha)
+
+        ## Test __call__ method
+        gv(sps=8, R=10e9, wavelength=1549e-9, N=10, alpha=0.2)
+
+        assert_(gv.sps == 8)
+        assert_(gv.R == 10e9)
+        assert_(gv.fs == 80e9)
+        assert_(gv.dt == 1/80e9)
+        assert_(gv.wavelength == 1549e-9)
+        assert_(gv.f0 == c/1549e-9)
+        assert_(gv.N == 10)
+        assert_equal(gv.t, np.linspace(0, gv.N*gv.sps*gv.dt, gv.N*gv.sps, endpoint=True))
+        assert_(gv.dw is not None)
+        assert_allclose(gv.w, np.fft.fftshift(np.fft.fftfreq(gv.N*gv.sps, gv.dt))*2*pi, atol=0)
+        assert_(gv.alpha == 0.2)
+
+        ## Test print
+        try:
+            gv.print()
+        except Exception as e:
+            self.fail(f"gv.print() raised {type(e).__name__} unexpectedly!")
+
+class TestBinarySequence(unittest.TestCase):
+    inputs = ['000011110000',
+                [0,0,0,0,1,1,1,1,0,0,0,0],
+                (0,0,0,0,1,1,1,1,0,0,0,0),
+                np.array([0,0,0,0,1,1,1,1,0,0,0,0])]
+    
+    def test_init(self):
+        for input in self.inputs:
+            with self.subTest(input_type=type(input)):
+                bits = binary_sequence(input)
+                assert_((bits == [0,0,0,0,1,1,1,1,0,0,0,0]).data.all()) # Check if the data is correct, and test the __eq__ method
+                assert_(bits.len() == 12) # Check that the length is correct, and test the len method
+                assert_(bits.execution_time is None) # Check that the execution time is None
+
+    def test_print(self):
+        for input in self.inputs:
+            with self.subTest(input_type=type(input)):
+                bits = binary_sequence(input)
+                try:
+                    bits.print()
+                except Exception as e:
+                    self.fail(f"bits.print() raised {type(e).__name__} unexpectedly!")
+    
+    def test_getitem(self):
+        for input in self.inputs:
+            with self.subTest(input_type=type(input)):
+                bits = binary_sequence(input)
+                assert_(bits[0] == 0)
+                assert_((bits[:] == [0,0,0,0,1,1,1,1,0,0,0,0]).data.all())
+                assert_((bits[4:-1] == [1,1,1,1,0,0,0]).data.all())
+                assert_raises(IndexError, lambda: bits[12])
+
+    def test_add_and_radd(self):
+        for input in self.inputs:
+            with self.subTest(input_type=type(input)):
+                bits = binary_sequence(input)
+                
+                assert_((bits + bits == [0,0,0,0,1,1,1,1,0,0,0,0,0,0,0,0,1,1,1,1,0,0,0,0]).data.all())
+                assert_((bits + '0101' == [0,0,0,0,1,1,1,1,0,0,0,0,0,1,0,1]).data.all())
+                assert_(('0101' + bits == [0,1,0,1,0,0,0,0,1,1,1,1,0,0,0,0]).data.all())
+                assert_raises(TypeError, lambda: bits + 1)
+                assert_raises(TypeError, lambda: 1 + bits)
+                assert_raises(ValueError, lambda: '020' + bits)
+                assert_raises(ValueError, lambda: bits + [0,3,0])
+                
+    def test_invert(self):
+        for input in self.inputs:
+            with self.subTest(input_type=type(input)):
+                bits = binary_sequence(input)
+                assert_((~bits == [1,1,1,1,0,0,0,0,1,1,1,1]).data.all())
+    
+    def test_ones_and_zeros(self):
+        for input in self.inputs:
+            with self.subTest(input_type=type(input)):
+                bits = binary_sequence(input)
+                assert_(bits.ones() == 4)
+                assert_(bits.zeros() == 8)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/typing_test.py
+++ b/tests/typing_test.py
@@ -75,6 +75,9 @@ class TestBinarySequence(unittest.TestCase):
     assert_raises(ValueError, lambda: binary_sequence('001;101'))
     
     def test_init(self):
+        assert_(binary_sequence(0).data==0)
+        assert_(binary_sequence('1').data==1)
+
         for input in self.inputs:
             with self.subTest(input_type=type(input)):
                 bits = binary_sequence(input)
@@ -90,15 +93,15 @@ class TestBinarySequence(unittest.TestCase):
         except Exception as e:
             self.fail(f"bits.print() raised {type(e).__name__} unexpectedly!")
     
-    def test_getitem(self):
+    def test_getitem_and_eq(self):
         for input in self.inputs:
             with self.subTest(input_type=type(input)):
                 bits = binary_sequence(input)
-                assert_(bits[0] == 0)
+                assert_((bits[0] == 0).data)
                 assert_((bits[:] == [0,0,0,0,1,1,1,1,0,0,0,0]).data.all())
                 assert_((bits[4:-1] == [1,1,1,1,0,0,0]).data.all())
                 assert_raises(IndexError, lambda: bits[12])
-
+    
     def test_add_and_radd(self):
         for input in self.inputs:
             with self.subTest(input_type=type(input)):
@@ -215,11 +218,11 @@ class TestElectricalSignal(unittest.TestCase):
             with self.subTest(input_type=type(input)):
                 signal = electrical_signal(input)
                 
-                assert_equal((signal + 1 > 0),  np.ones(100))
-                assert_equal((signal < 100), np.ones(100))
+                assert_equal((signal + 1 > 0).data,  np.ones(100))
+                assert_equal((signal < 100).data, np.ones(100))
 
-                assert_equal((signal > input),  np.zeros(100))
-                assert_equal((signal < input),  np.zeros(100))
+                assert_equal((signal > input).data,  np.zeros(100))
+                assert_equal((signal < input).data,  np.zeros(100))
                 assert_raises(ValueError, lambda: signal > input[:4])
 
     def test_call(self):
@@ -571,26 +574,26 @@ class TestOpticalSignal(unittest.TestCase):
     def test_plot(self):
         x = optical_signal(np.ones(100), np.random.normal(0,0.05,100), n_pol=1)
         try:
-            assert_(x.plot('--r', n=98, mode='x', xlabel='Time', ylabel='Intensity', style='light', grid=True, hold=False)==x)
+            assert_(x.plot('--r', n=98, mode='x', xlabel='Time', ylabel='Intensity', style='light', grid=True, hold=True)==x)
         except Exception as e:
             self.fail(f"x.plot() raised {type(e).__name__} unexpectedly!")
 
         x = optical_signal(np.ones(100), np.random.normal(0,0.05,100), n_pol=2)
         try:
-            assert_(x.plot(['r','b'], n=98, mode='both', xlabel='Time', ylabel='Intensity', style='dark', grid=True, hold=False)==x)
+            assert_(x.plot(['r','b'], n=98, mode='both', xlabel='Time', ylabel='Intensity', style='dark', grid=True, hold=True)==x)
         except Exception as e:
             self.fail(f"x.plot() raised {type(e).__name__} unexpectedly!")
 
     def test_psd(self):
         x = optical_signal(np.ones(100), np.random.normal(0,0.05,100), n_pol=1)
         try:
-            assert_(x.psd('--r', mode='x', n=98, xlabel='Freq', ylabel='Spectra', style='light', grid=True, hold=False)==x)
+            assert_(x.psd('--r', mode='x', n=98, xlabel='Freq', ylabel='Spectra', style='light', grid=True, hold=True)==x)
         except Exception as e:
             self.fail(f"x.psd() raised {type(e).__name__} unexpectedly!")
 
         x = optical_signal(np.ones(100), np.random.normal(0,0.05,100), n_pol=2)
         try:
-            assert_(x.psd('--b', mode='both', n=98, xlabel='Freq', ylabel='Spectra', style='dark', grid=False, hold=False)==x)
+            assert_(x.psd('--b', mode='both', n=98, xlabel='Freq', ylabel='Spectra', style='dark', grid=False, hold=True)==x)
         except Exception as e:
             self.fail(f"x.psd() raised {type(e).__name__} unexpectedly!")
 

--- a/tests/typing_test.py
+++ b/tests/typing_test.py
@@ -18,7 +18,8 @@ from opticomlib.typing import (
     gv
 )
 
-
+from opticomlib.devices import GET_EYE
+import matplotlib.pyplot as plt
 
 
 class TestGlobalVariables(unittest.TestCase):
@@ -556,22 +557,36 @@ class TestOpticalSignal(unittest.TestCase):
     def test_plot(self):
         x = optical_signal(np.ones(100), np.random.normal(0,0.05,100), n_pol=1)
         try:
-            assert_(x.plot('--r', n=98, mode='x', xlabel='Time', ylabel='Intensity', style='light', grid=True)==x)
+            assert_(x.plot('--r', n=98, mode='x', xlabel='Time', ylabel='Intensity', style='light', grid=True, hold=False)==x)
         except Exception as e:
             self.fail(f"x.plot() raised {type(e).__name__} unexpectedly!")
 
         x = optical_signal(np.ones(100), np.random.normal(0,0.05,100), n_pol=2)
         try:
-            assert_(x.plot(['r','b'], n=98, mode='both', xlabel='Time', ylabel='Intensity', style='dark', grid=True)==x)
+            assert_(x.plot(['r','b'], n=98, mode='both', xlabel='Time', ylabel='Intensity', style='dark', grid=True, hold=False)==x)
         except Exception as e:
             self.fail(f"x.plot() raised {type(e).__name__} unexpectedly!")
 
     def test_psd(self):
         x = optical_signal(np.ones(100), np.random.normal(0,0.05,100), n_pol=1)
         try:
-            assert_(x.psd('--r', mode='both', n=98, xlabel='Time', ylabel='Intensity', style='light', grid=True)==x)
+            assert_(x.psd('--r', mode='both', n=98, xlabel='Time', ylabel='Intensity', style='light', grid=True, hold=False)==x)
         except Exception as e:
             self.fail(f"x.psd() raised {type(e).__name__} unexpectedly!")
+
+
+class testEye(unittest.TestCase):
+    def test_eye(self):
+        x = eye()
+
+        assert_raises(ValueError, lambda: x.print())
+        assert_raises(ValueError, lambda: x.plot())
+
+        sig = np.kron(10*[1,0], np.ones(128)) + np.random.normal(0,0.05,128*20)
+        
+        x = GET_EYE(sig) # this returns an eye object with estimated parameters
+        
+        assert_(x.plot(medias_=True, legend_=True, style='light', cmap='plasma', label='TEST')==x)
 
 
 if __name__ == '__main__':

--- a/tests/typing_test.py
+++ b/tests/typing_test.py
@@ -63,9 +63,14 @@ class TestGlobalVariables(unittest.TestCase):
 
 class TestBinarySequence(unittest.TestCase):
     inputs = ['000011110000',
-                [0,0,0,0,1,1,1,1,0,0,0,0],
-                (0,0,0,0,1,1,1,1,0,0,0,0),
-                np.array([0,0,0,0,1,1,1,1,0,0,0,0])]
+            [0,0,0,0,1,1,1,1,0,0,0,0],
+            (0,0,0,0,1,1,1,1,0,0,0,0),
+            np.array([0,0,0,0,1,1,1,1,0,0,0,0])]
+    
+    assert_raises(TypeError, lambda: binary_sequence())
+    assert_raises(ValueError, lambda: binary_sequence([0,1,2,3]))
+    assert_raises(ValueError, lambda: binary_sequence('001201'))
+    assert_raises(ValueError, lambda: binary_sequence('001;101'))
     
     def test_init(self):
         for input in self.inputs:
@@ -104,7 +109,9 @@ class TestBinarySequence(unittest.TestCase):
                 assert_raises(TypeError, lambda: bits + 1)
                 assert_raises(TypeError, lambda: 1 + bits)
                 assert_raises(ValueError, lambda: '020' + bits)
+                assert_raises(ValueError, lambda: bits + '020')
                 assert_raises(ValueError, lambda: bits + [0,3,0])
+                assert_raises(ValueError, lambda: [0,3,0] + bits)
                 
     def test_invert(self):
         for input in self.inputs:
@@ -123,13 +130,12 @@ class TestBinarySequence(unittest.TestCase):
 
 
 class TestElectricalSignal(unittest.TestCase):
-    inputs = [np.arange(100).tolist(), np.arange(100)] 
+    inputs = [np.arange(100).tolist().__str__().strip('[]'), np.arange(100).tolist(), np.arange(100)] 
 
     def test_init(self):
-        assert_raises(KeyError, lambda: electrical_signal())
+        assert_raises(TypeError, lambda: electrical_signal())
         assert_raises(ValueError, lambda: electrical_signal([0,1,2], [0,1,2,3]))
         assert_raises(ValueError, lambda: electrical_signal([0,1,2,3], [0,1,2]))
-        assert_raises(TypeError, lambda: electrical_signal(signal='0,0.1,0.2,0.3'))
         assert_raises(ValueError, lambda: electrical_signal([[1,2,3]]))
 
         for input in self.inputs:
@@ -202,19 +208,19 @@ class TestElectricalSignal(unittest.TestCase):
         for input in self.inputs:
             with self.subTest(input_type=type(input)):
                 signal = electrical_signal(input)
-                assert_equal(signal('t').signal, np.fft.ifft(input))
-                assert_equal(signal('f').signal, np.fft.fft(input))
-                assert_equal(signal('w').signal, np.fft.fft(input))
+                assert_equal(signal('t').signal, np.fft.ifft(np.arange(100)))
+                assert_equal(signal('f').signal, np.fft.fft(np.arange(100)))
+                assert_equal(signal('w').signal, np.fft.fft(np.arange(100)))
                 assert_raises(ValueError, lambda: signal('z'))
 
-                assert_equal(signal('t', shift=True).signal, np.fft.ifftshift(np.fft.ifft(input)))
+                assert_equal(signal('t', shift=True).signal, np.fft.ifftshift(np.fft.ifft(np.arange(100))))
     
     def test_power(self):
         for input in self.inputs:
             with self.subTest(input_type=type(input)):
                 signal = electrical_signal(input, noise=np.ones(100))
-                assert_equal(signal.power(), np.sum(np.abs(input + signal.noise)**2)/len(input))
-                assert_equal(signal.power('signal'), np.sum(np.abs(input)**2)/len(input))
+                assert_equal(signal.power(), np.sum(np.abs(np.arange(100) + signal.noise)**2)/100)
+                assert_equal(signal.power('signal'), np.sum(np.abs(np.arange(100))**2)/100)
                 assert_equal(signal.power('noise'), 1)
                 assert_raises(ValueError, lambda: signal.power('z'))
 
@@ -222,8 +228,8 @@ class TestElectricalSignal(unittest.TestCase):
         for input in self.inputs:
             with self.subTest(input_type=type(input)):
                 signal = electrical_signal(input, noise=np.ones(100))
-                assert_equal(signal.abs(), np.abs(input + signal.noise))
-                assert_equal(signal.abs('signal'), np.abs(input))
+                assert_equal(signal.abs(), np.arange(100)+1)
+                assert_equal(signal.abs('signal'), np.arange(100))
                 assert_equal(signal.abs('noise'), np.ones(100))
                 assert_raises(ValueError, lambda: signal.abs('z'))
 
@@ -231,13 +237,13 @@ class TestElectricalSignal(unittest.TestCase):
         for input in self.inputs:
             with self.subTest(input_type=type(input)):
                 signal = electrical_signal(input, noise=np.ones(100))
-                assert_equal(signal.phase(), np.unwrap(np.angle(input + signal.noise)))
+                assert_equal(signal.phase(), np.unwrap(np.angle(np.arange(100) + signal.noise)))
     
     def test_apply(self):
         for input in self.inputs:
             with self.subTest(input_type=type(input)):
                 signal = electrical_signal(input, noise=np.ones(100))
-                assert_equal(signal.apply(np.abs).signal, np.abs(input))
+                assert_equal(signal.apply(np.abs).signal, np.arange(100))
                 assert_equal(signal.apply(np.abs).noise, np.abs(signal.noise))
 
 


### PR DESCRIPTION
## Bump version to `v1.0.0`

## ✨ Features:
### On Binary Sequence:
- Add scalar support ([a665f72](https://github.com/armando-palacio/opticomlib/pull/22/commits/a665f7277d671088da155a48a6740e79e237b1a9))
  ```Python
  >>> binary_sequence(1)
  binary_sequence([1])
  ```
### On Electrical Signal
- Add `__repr__` method and improve printing style. If `noise` is zeros array it is not printed.
  ```Python
  >>> electrical_signal([1,2,3,4], [0,0,0,0])
  electrical_signal([1 2 3 4])
  ```
- `signal` and `noise` keep type of input arrays (before it were set as `complex`).
- Now accept `strings` as inputs. 
  ```Python 
  >>> electrical_signal('1,2,3,4', '0 0.1 0.3 -0.1')
  electrical_signal(signal=[1. 2. 3. 4.],
                     noise=[ 0.   0.1  0.3 -0.1])
  ```
- Scalars values are accepted now as input
- Add support for substact `-`. Can substracct an `int`, `str`, `iterable`, `electrical_signal`.
  ```Python
  >>> electrical_signal('1 2 3 4') - 1
  electrical_signal([0 1 2 3])
  >>> electrical_signal('1 2 3 4') - '1 1 2 2j'
  electrical_signal([0.+0.j 1.+0.j 1.+0.j 4.-2.j])
  ```
- Add a new parameter `hold=True` in plot and psd methods to manage if create or not a new figure.
- `phase` function now calculate phase of signal + noise (before only signal).
### On Optical Signal
- Scalar inputs are now supported.
- Can drive 1 or 2 polarizations now (new attribute `n_pol` was added). If 1 polarization, signal and noise arrays will have shapes (N,). If 2 polarizations, signal and noise will have shapes (2,N). Number of polarizations are detected automatically from inputs shapes or can be forced by `n_pol` argument.
  ```Python
  >>> optical_signal([[1,2,3,4]])  # automatically detect 2 polarizations
  optical_signal([[1 2 3 4]
                  [1 2 3 4]])
  >>> optical_signal([[1,2,3,4]], n_pol=1)  # force 1 polarization
  optical_signal([1 2 3 4])
  ```
- `phase` function now calculate phase of signal + noise (before only signal).
- `power`, `abs` and `__call__` functions now accept capital letters as inputs.
- `signal` and `noise` keep type of input arrays (before it were set as `complex`).
- Now accept `strings` as inputs. 
- Add support for substact `-`. Can substracct an `int`, `str`, `iterable`, `optical_signal`.
- Add a new parameter `hold=True` in plot and psd methods to manage if create or not a new figure.

### Others
- utils.str2array enhancement. This function now autodetect the output array type from string format if dtype is not given. Support more than one row, using semicolon `;` to separate the rows. Support `complex` output type.
  ```Python
  >>> str2array('1 2 3 4')  # type int
  array([1, 2, 3, 4])
  >>> str2array('1.1 2.2 3.3 4.4')  # type float
  array([1.1, 2.2, 3.3, 4.4])
  >>> str2array('101001')  # type bool
  array([ True, False,  True, False, False,  True])  
  >>> str2array('1 2 3 4+2j')  # type complex
  array([1.+0.j, 2.+0.j, 3.+0.j, 4.+2.j])
  >>> str2array('1 2 3 4; 5 6 7 8')  # more than one raw
  array([[1, 2, 3, 4],
         [5, 6, 7, 8]])
  >>> str2array('1+3j 2+4j 3+5j 4+6j', dtype=int)  # can force a type
  array([1, 2, 3, 4])
  ```


## 🧪 Tests:
- [x] Added unittest for `global_variables`
- [x] Added unittest for `binary_sequence`
- [x] Added unittest for `electrical_signal`
- [x] Added unittest for `optical_signal`
- [x] Added unittest for `eye` 

## 🐛 Bugs:
- fix a bug in `electrical_signal.__lt__`, operator `<` was inverted.
- reforze inizilization functions of objects.
- add a check for same length in `__add__`, `__sub__`, `__rsub__`, `__mul__`, `__gt__` and `__lt__`.
- fix eye calculation error of `devices.GET_EYE` when there are not enough data to estimate the cross time. Default values were set when this happend (`t_left=-0.5`, `t_right=0.5` and `t_center=0`).

## 💥 BREAKING CHANGE
- Update python requirements to ` >=3.10` in order to express arguments type separated by `|` instead of use `Union[]`