### PR TITLE
PRBS device upgarde

### DIFF
--- a/opticomlib/__init__.py
+++ b/opticomlib/__init__.py
@@ -1,5 +1,5 @@
 from .typing import *
 from .utils import *
 
-__version__ = '1.0.0'
+__version__ = '1.1.0'
 

--- a/opticomlib/devices.py
+++ b/opticomlib/devices.py
@@ -58,7 +58,9 @@ from .utils import (
 )
 
 def PRBS(order: Literal[7, 9, 11, 15, 20, 23, 31], 
-         len: int = None):
+         len: int = None,
+         seed: int = None,
+         return_seed: bool = False):
     r"""**Pseudorandom binary sequence generator**
 
     Parameters
@@ -67,6 +69,11 @@ def PRBS(order: Literal[7, 9, 11, 15, 20, 23, 31],
         degree of the generating pseudorandom polynomial
     len : :obj:`int`, optional
         lenght of output binary sequence
+    seed : :obj:`int`, optional
+        seed of the generator (initial state of the LFSR). It must be provided if you want to continue the sequence.
+        Default is 2**order-1.
+    return_seed : :obj:`bool`, optional
+        If True, the last state of LFSR is returned. Default is False.
 
     Returns
     -------
@@ -79,25 +86,28 @@ def PRBS(order: Literal[7, 9, 11, 15, 20, 23, 31],
         If ``order`` is not in [7, 9, 11, 15, 20, 23, 31].
     TypeError
         If ``len`` is not an integer.
+    
+    Warnings
+    --------
+    UserWarning
+        If the seed is 0 or a multiple of 2**order.
 
     Examples
     --------
-    For more details, see [prbs]_.
-
+    You can generate a PRBS sequence using the following code:
+    
     >>> from opticomlib.devices import PRBS
-    >>> PRBS(7, len=10).print("PRBS")
+    >>> PRBS(order=7, len=10)
+    binary_sequence([1 0 0 0 0 0 0 1 0 0])
+    >>> PRBS(order=31, len=20)
+    binary_sequence([1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0])
 
-    :: 
-  
-        -----------------------------
-        ***    binary_sequence    ***
-        -----------------------------
-            data  :  [1 0 0 0 0 0 0 1 0 0]
-            len   :  10
-            size  :  440 bytes
-            time  :  0 s
+    You can fix the LFSR iniitial state of generator by using the following code:
+    
+    >>> PRBS(order=7, len=10, seed=124)
+    binary_sequence([0 0 0 0 0 1 0 0 0 0])
 
-        <opticomlib.typing.binary_sequence object at 0x000002385FD7D7F0>
+    For more details, see [prbs]_.
 
     References
     ----------
@@ -105,19 +115,22 @@ def PRBS(order: Literal[7, 9, 11, 15, 20, 23, 31],
     """
     tic()
     taps = {7: [7,6], 9: [9,5], 11: [11,9], 15: [15,14], 20: [20,3], 23: [23,18], 31: [31,28]}
+    seed = seed%(2**order) if seed is not None else (1<<order)-1
+    if seed == 0:
+        seed = 1
+        warnings.warn('The seed can\'t be 0 or a multiple of 2**order. It has been changed to 1.', UserWarning)
     
     if len is not None:
         if not isinstance(len, int):
             raise TypeError('The parameter `len` must be an integer.')
-        len = min(len, 2**order-1)
     else:
         len = 2**order-1
     
     if order not in taps.keys():
         raise ValueError('The parameter `order` must be one of the following values (7, 9, 11, 15, 20, 23, 31).')
 
-    prbs = np.empty((len,), dtype=np.uint8)  # Preallocate memory
-    lfsr = (1<<order)-1 # initial state of the LFSR
+    prbs = np.empty((len,), dtype=np.uint8)  # Preallocate memory for the PRBS
+    lfsr = seed # initial state of the LFSR 
     tap1, tap2 = np.array(taps[order])-1
 
     index = 0
@@ -126,13 +139,15 @@ def PRBS(order: Literal[7, 9, 11, 15, 20, 23, 31],
         new = ((lfsr>>tap1)^(lfsr>>tap2))&1
         lfsr = ((lfsr<<1) | new) & (1<<order)-1 
         index += 1
-        if lfsr == (1<<order)-1:
-            break
+        # if lfsr == seed:
+        #     break
     
     output = binary_sequence( prbs )
     output.execution_time = toc()
     
-    return output
+    if not return_seed:
+        return output
+    return output, lfsr   
 
 
 def DAC(input: Union[str, list, tuple, np.ndarray, binary_sequence], 
@@ -532,7 +547,7 @@ def BPF(input: optical_signal,
 
     sos_band = sg.bessel(N=n, Wn=BW/2, btype='low', fs=gv.fs, output='sos', norm='mag')
 
-    output = optical_signal(np.zeros((2, input.len())))
+    output = input.copy()
 
     output.signal = sg.sosfiltfilt(sos_band, input.signal, axis=-1)
 

--- a/opticomlib/devices.py
+++ b/opticomlib/devices.py
@@ -87,8 +87,8 @@ def PRBS(order: Literal[7, 9, 11, 15, 20, 23, 31],
     TypeError
         If ``len`` is not an integer.
     
-    Warnings
-    --------
+    Warns
+    -----
     UserWarning
         If the seed is 0 or a multiple of 2**order.
 
@@ -107,7 +107,18 @@ def PRBS(order: Literal[7, 9, 11, 15, 20, 23, 31],
     >>> PRBS(order=7, len=10, seed=124)
     binary_sequence([0 0 0 0 0 1 0 0 0 0])
 
+
+    Notes
+    -----
     For more details, see [prbs]_.
+
+    - :math:`2^7-1` bits. Polynomial :math:`= X^7 + X^6 + 1`
+    - :math:`2^9-1` bits. Polynomial :math:`= X^9 + X^5 + 1`
+    - :math:`2^{11}-1` bits. Polynomial :math:`= X^{11} + X^9 + 1`
+    - :math:`2^{15}-1` bits. Polynomial :math:`= X^{15} + X^{14} + 1`
+    - :math:`2^{20}-1` bits. Polynomial :math:`= X^{20} + X^3 + 1`
+    - :math:`2^{23}-1` bits. Polynomial :math:`= X^{23} + X^{18} + 1`
+    - :math:`2^{31}-1` bits. Polynomial :math:`= X^{31} + X^{28} + 1`
 
     References
     ----------
@@ -123,6 +134,8 @@ def PRBS(order: Literal[7, 9, 11, 15, 20, 23, 31],
     if len is not None:
         if not isinstance(len, int):
             raise TypeError('The parameter `len` must be an integer.')
+        elif len<=0:
+            raise ValueError('The parameter `len` must be an integer greater than cero.')
     else:
         len = 2**order-1
     

--- a/tests/devices_test.py
+++ b/tests/devices_test.py
@@ -1,18 +1,49 @@
 import unittest
 import numpy as np
 
+from numpy.testing import (
+    assert_,
+    assert_allclose,
+    assert_almost_equal,
+    assert_equal,
+    assert_raises,
+)
+
+from opticomlib import (
+    binary_sequence
+)
+
 from opticomlib.devices import (
     PRBS,
 )
 class TestDevices(unittest.TestCase):
     def test_PRBS(self):
-        with self.assertRaises(TypeError):
-            PRBS(order=15, len='20') # len must be an integer
-        with self.assertRaises(ValueError):
-            PRBS(order=8) # order must be one of [7, 9, 11, 15, 20, 23, 31]
+        assert_raises(TypeError, PRBS, order=15, len='20') # len must be an integer
+        assert_raises(ValueError, PRBS, order=8) # order must be one of [7, 9, 11, 15, 20, 23, 31]
+        assert_raises(ValueError, PRBS, order=7, len=0) # len must be greater than 0
 
-        prbs = PRBS(order=15, len=20)
-        self.assertEqual(len(prbs), 20) 
+        assert_equal(PRBS(7, len=10, seed=0), [1,0,0,0,0,0,1,1,0,0]) # if seed=0 it will be set to 1
+
+        # for default seed
+        data_out = [[1,0,0,0,0,0,0,1,0,0,0,0,0,1,1,0,0,0,0,1], # first 20 bits of PRBS7
+                    [1,0,0,0,0,0,1,1,1,1,0,1,1,1,1,1,0,0,0,1], # first 20 bits of PRBS9
+                    [1,0,0,0,0,0,0,0,0,0,1,1,0,0,0,0,0,0,0,1], # first 20 bits of PRBS11
+                    [1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1,0,0,0,0], # first 20 bits of PRBS15
+                    [1,0,0,0,1,1,1,0,0,0,1,1,1,0,0,0,1,1,1,0], # first 20 bits of PRBS20
+                    [1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1], # first 20 bits of PRBS23
+                    [1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]] # first 20 bits of PRBS31
+
+        for i, order in enumerate([7, 9, 11, 15, 20, 23, 31]):
+            with self.subTest(order=order):
+                prbs = PRBS(order=order, len=20)
+                
+                assert_equal(len(prbs), 20)
+                assert_(prbs.type() == binary_sequence)
+                assert_equal(prbs.data, data_out[i])
+
+        assert_equal(PRBS(7, len=2*127), PRBS(7, len=127).data.tolist()*2) # checking lengths longer than 2**order-1
+
+            
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## 🚀 Bump version to v1.1.0

## ✨ Features:
- new parameters `seed` and `return_seed` was added. `seed` permit to set the initial state of the  linear feedback shift register (LFSR) and `return_seed` return the final value of LFSR for future uses.
- now output length larger than 2**order-1 is available.

## 🛠️ Maintenance:
- update docstring examples

## 🧪 Tests:
- Add unit-tests to `devices_test.py`