### PR TITLE
Upgrade DAC device

### DIFF
--- a/opticomlib/__init__.py
+++ b/opticomlib/__init__.py
@@ -1,5 +1,5 @@
 from .typing import *
 from .utils import *
 
-__version__ = '1.3.0'
+__version__ = '1.4.0'
 


### PR DESCRIPTION
## 🚀 Bump version to `v1.4.0`

## ✨ Features:
- Now a bias can be added to the output signal throught `bias` parameter.
- `'nrz'` and `'rz'` options were added as pulse_shape options. `'nrz'` is the same than `'rect'`. 
- Now can limit the bandwidth of electrical output passing it to `BW` parameter. It apply a low pass filter (LPF) to the output signal.
- Boundary conditions have been added to the parameters to avoid silent errors. An Exception is raised if conditions are not rights.

## 🧪 Tests:
- [x] Add unittest for `devices.DAC`